### PR TITLE
Fixed. The 'font-family' and 'font-size' changed

### DIFF
--- a/src/components/app/app-theme/typography.styles.js
+++ b/src/components/app/app-theme/typography.styles.js
@@ -52,7 +52,7 @@ export default {
     lineHeight: '21px'
   },
   body2: {
-    fontSize: '12px',
+    fontSize: '16px',
     letterSpacing: '-0.04px',
     lineHeight: '18px'
   },
@@ -70,5 +70,19 @@ export default {
     letterSpacing: '0.33px',
     lineHeight: '13px',
     textTransform: 'uppercase'
-  }
+  },
+  fontFamily: [
+    '"Montserrat"',
+    '-apple-system',
+    'BlinkMacSystemFont',
+    '"Segoe UI"',
+    'Roboto',
+    'Oxygen',
+    'Ubuntu',
+    'Cantarell',
+    'Fira Sans',
+    'Droid Sans',
+    '"Helvetica Neue"',
+    'sans-serif'
+  ]
 };

--- a/src/pages/main-page/main-page.styles.js
+++ b/src/pages/main-page/main-page.styles.js
@@ -73,7 +73,7 @@ export const useStyles = makeStyles((theme) => ({
     justifyContent: 'space-between'
   },
   commentText: {
-    fontSize: '1.1em',
+    fontSize: '16px',
     marginBottom: 5
   },
   changesContainer: {


### PR DESCRIPTION
## Description

src/components/app/app-theme/thypography.styles.js

Changed "fontSize" proprety in "body2" property and add "fontFamily" property.



#### Screenshots

Original             |  Updated
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/54583764/111299489-a77a8280-8658-11eb-94e7-6188824c1f49.png) | ![image](https://user-images.githubusercontent.com/54583764/111299536-b6613500-8658-11eb-870d-42ae9f719780.png)



### Checklist
- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅ All tests passed locally
- [x] ✨ My changes working with up-to-date front-end and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
