### PR TITLE
The button 'Зберегти' isn't clickable and error message doesn't appear

### DIFF
--- a/src/components/forms/category-form/category-form.js
+++ b/src/components/forms/category-form/category-form.js
@@ -95,7 +95,7 @@ const CategoryForm = ({ category, id, edit }) => {
         category: newCategory,
         upload
       });
-      if (!uploadCondition) {
+      if (!uploadCondition && !category.images.thumbnail) {
         dispatch(setSnackBarSeverity('error'));
         dispatch(setSnackBarMessage(CATEGORY_ERROR));
         dispatch(setSnackBarStatus(true));

--- a/src/components/forms/category-form/category-form.js
+++ b/src/components/forms/category-form/category-form.js
@@ -95,10 +95,11 @@ const CategoryForm = ({ category, id, edit }) => {
         category: newCategory,
         upload
       });
-
-      dispatch(setSnackBarSeverity('error'));
-      dispatch(setSnackBarMessage(CATEGORY_ERROR));
-      dispatch(setSnackBarStatus(true));
+      if (!uploadCondition) {
+        dispatch(setSnackBarSeverity('error'));
+        dispatch(setSnackBarMessage(CATEGORY_ERROR));
+        dispatch(setSnackBarStatus(true));
+      }
     }
   });
 
@@ -168,7 +169,11 @@ const CategoryForm = ({ category, id, edit }) => {
           type='submit'
           title={SAVE_TITLE}
           errors={errors}
-          values={values}
+          values={{
+            uaName: values.uaName,
+            enName: values.enName,
+            code: values.code
+          }}
         />
       </form>
     </div>


### PR DESCRIPTION
When we enter valid data without the image the button 'Зберегти' is clickable now and warning message is displayed: 'Додайте зображення до категорії' after clicking on 'Зберегти' button

![image](https://user-images.githubusercontent.com/61886864/112964164-be3cd100-9150-11eb-846f-17825a483ea4.png)
![image](https://user-images.githubusercontent.com/61886864/112964208-c85ecf80-9150-11eb-84f2-af4ed552de5b.png)



### Checklist
- [ ] 🔽 My branch is up-to-date with "development" branch
- [ ] ✅ All tests passed locally
- [ ] ✨ My changes working with up-to-date front-end and back-end part locally, like charm
- [ ] 🔗 Link pull request to issue
