### PR TITLE
Bug fix/848 2

### DIFF
--- a/src/components/buttons/save-button/save-button.js
+++ b/src/components/buttons/save-button/save-button.js
@@ -5,7 +5,6 @@ import { Button } from '@material-ui/core';
 import PropTypes from 'prop-types';
 import { noop } from 'lodash';
 
-import { createBrowserHistory } from 'history';
 import useSuccessSnackbar from '../../../utils/use-success-snackbar';
 import { closeDialog } from '../../../redux/dialog-window/dialog-window.actions';
 import messages from '../../../configs/messages';
@@ -36,15 +35,14 @@ const SaveButton = ({
   }, [disable, values, error]);
 
   const dispatch = useDispatch();
-  const history = createBrowserHistory();
   const { openSuccessSnackbar } = useSuccessSnackbar();
 
   const { SAVE_MESSAGE, SAVE_CHANGES } = messages;
 
   const saveButtonHandler = () => {
     const backAction = () => {
+      onClickHandler();
       dispatch(closeDialog());
-      history.goBack();
     };
     openSuccessSnackbar(backAction, SAVE_MESSAGE, SAVE_CHANGES);
   };

--- a/src/components/dialog-window/dialog-window.js
+++ b/src/components/dialog-window/dialog-window.js
@@ -45,14 +45,11 @@ const DialogWindow = ({
             <StandardButton
               data-cy='dialog-cancel'
               variant='outlined'
-              title={NO_BUTTON}
-              onClickHandler={handleClose}
-            />
-            <DeleteButton
-              data-cy='dialog-confirm'
+              title={YES_BUTTON}
               onClickHandler={onClickHandler}
-            >
-              {YES_BUTTON}
+            />
+            <DeleteButton data-cy='dialog-confirm' onClickHandler={handleClose}>
+              {NO_BUTTON}
             </DeleteButton>
           </>
         ) : (

--- a/src/components/forms/business-page-form/business-page-form.js
+++ b/src/components/forms/business-page-form/business-page-form.js
@@ -167,6 +167,10 @@ const BusinessPageForm = ({ id, editMode }) => {
     values
   );
 
+  const eventPreventHandler = (e) => {
+    e.preventDefault();
+  };
+
   return (
     <div className={common.container}>
       <div className={common.adminHeader}>
@@ -178,7 +182,7 @@ const BusinessPageForm = ({ id, editMode }) => {
           {config.titles.businessPageTitles.addBusinessPageTitle}
         </Typography>
       </div>
-      <form onSubmit={handleSubmit}>
+      <form onSubmit={(e) => eventPreventHandler(e)}>
         <div>
           <Grid item xs={12}>
             <Paper className={classes.businessPageForm}>
@@ -212,6 +216,7 @@ const BusinessPageForm = ({ id, editMode }) => {
             type='submit'
             title='Зберегти'
             data-cy='save-btn'
+            onClickHandler={handleSubmit}
             values={{
               code: values.code,
               uaTitle: values.uaTitle,

--- a/src/components/forms/category-form/category-form.js
+++ b/src/components/forms/category-form/category-form.js
@@ -128,9 +128,13 @@ const CategoryForm = ({ category, id, edit }) => {
     values
   );
 
+  const eventPreventHandler = (e) => {
+    e.preventDefault();
+  };
+
   return (
     <div>
-      <form onSubmit={handleSubmit}>
+      <form onSubmit={(e) => eventPreventHandler(e)}>
         <Grid item xs={12}>
           <Paper className={styles.categoryItemUpdate}>
             <span className={styles.imageUpload}>
@@ -169,6 +173,7 @@ const CategoryForm = ({ category, id, edit }) => {
         <SaveButton
           className={styles.saveCategoryButton}
           data-cy='save'
+          onClickHandler={handleSubmit}
           type={materialUiConstants.types.submit}
           title={SAVE_TITLE}
           errors={errors}

--- a/src/components/forms/category-form/tests/category-form.test.js
+++ b/src/components/forms/category-form/tests/category-form.test.js
@@ -101,7 +101,7 @@ describe('test СategoryForm', () => {
 
   it('Should simulate form submit', () => {
     wrapper.find('form').simulate('submit');
-    expect(mockSubmit).toHaveBeenCalledTimes(1);
+    expect(mockSubmit).toHaveBeenCalledTimes(0);
   });
 
   it('Should simulate submit button', () => {

--- a/src/components/forms/comment-form/comment-form.js
+++ b/src/components/forms/comment-form/comment-form.js
@@ -72,9 +72,13 @@ const CommentForm = ({ comment, id, isEdit }) => {
     history.push(pathToEditProduct.replace(':id', comment.product._id));
   }
 
+  const eventPreventHandler = (e) => {
+    e.preventDefault();
+  };
+
   return (
     <div>
-      <form onSubmit={handleSubmit}>
+      <form onSubmit={(e) => eventPreventHandler(e)}>
         <Grid item xs={12}>
           <CheckboxOptions options={checkboxes} />
           <Paper className={styles.paper}>
@@ -100,6 +104,7 @@ const CommentForm = ({ comment, id, isEdit }) => {
           <BackButton pathBack={pathToComments} />
           <SaveButton
             className={styles.saveCommentButton}
+            onClickHandler={handleSubmit}
             data-cy='save'
             type='submit'
             title={SAVE_TITLE}

--- a/src/components/forms/constructor-form/constructor-form.js
+++ b/src/components/forms/constructor-form/constructor-form.js
@@ -219,9 +219,13 @@ const ConstructorForm = ({ isEdit, editableConstructorElement }) => {
     inputs
   };
 
+  const eventPreventHandler = (e) => {
+    e.preventDefault();
+  };
+
   return (
     <div>
-      <form onSubmit={handleSubmit}>
+      <form onSubmit={(e) => eventPreventHandler(e)}>
         <CheckboxOptions options={checkboxes('available', show)} />
         <CheckboxOptions options={checkboxes('default', defaultElement)} />
         <Grid item xs={12}>
@@ -287,6 +291,7 @@ const ConstructorForm = ({ isEdit, editableConstructorElement }) => {
         <BackButton />
         <SaveButton
           className={styles.saveButton}
+          onClickHandler={handleSubmit}
           data-cy='save-btn'
           type='submit'
           title={SAVE_TITLE}

--- a/src/components/forms/contacts-form/contacts-form.js
+++ b/src/components/forms/contacts-form/contacts-form.js
@@ -130,9 +130,13 @@ const ContactsForm = ({ contactSaveHandler, initialValues }) => {
 
   const valueEquality = checkInitialValue(initialValues, values);
 
+  const eventPreventHandler = (e) => {
+    e.preventDefault();
+  };
+
   return (
     <div className={classes.detailsContainer}>
-      <form className={classes.form} onSubmit={handleSubmit}>
+      <form className={classes.form} onSubmit={(e) => eventPreventHandler(e)}>
         <FormControl className={classes.contactDetails}>
           <Grid container spacing={1}>
             <Grid item xs={12}>
@@ -254,6 +258,7 @@ const ContactsForm = ({ contactSaveHandler, initialValues }) => {
           id='save'
           type='submit'
           title='Зберегти'
+          onClickHandler={handleSubmit}
           className={classes.saveButton}
           data-cy='save'
           values={values}

--- a/src/components/forms/header-form/header-form.js
+++ b/src/components/forms/header-form/header-form.js
@@ -61,9 +61,13 @@ const HeaderForm = ({ header, id }) => {
     values
   );
 
+  const eventPreventHandler = (e) => {
+    e.preventDefault();
+  };
+
   return (
     <div>
-      <form onSubmit={handleSubmit}>
+      <form onSubmit={(e) => eventPreventHandler(e)}>
         <Grid item xs={12}>
           <Paper className={styles.headerItemUpdate}>
             <TextField
@@ -129,6 +133,7 @@ const HeaderForm = ({ header, id }) => {
         <BackButton initial={!valueEquality} pathBack={pathToHeaders} />
         <SaveButton
           className={styles.saveButton}
+          onClickHandler={handleSubmit}
           data-cy='save'
           type='submit'
           title={config.buttonTitles.HEADER_SAVE_TITLE}

--- a/src/components/forms/home-page-slide-form/home-page-slide-form.js
+++ b/src/components/forms/home-page-slide-form/home-page-slide-form.js
@@ -117,9 +117,13 @@ const HomePageSlideForm = ({ slide, id, slideOrder }) => {
     values
   );
 
+  const eventPreventHandler = (e) => {
+    e.preventDefault();
+  };
+
   return (
     <div className={styles.formContainer}>
-      <form onSubmit={handleSubmit}>
+      <form onSubmit={(e) => eventPreventHandler(e)}>
         <CheckboxOptions options={checkboxes} />
 
         <Grid item xs={12}>
@@ -159,6 +163,7 @@ const HomePageSlideForm = ({ slide, id, slideOrder }) => {
         <SaveButton
           className={styles.formButton}
           data-cy='save'
+          onClickHandler={handleSubmit}
           type='submit'
           title={config.buttonTitles.CREATE_SLIDE_TITLE}
           values={values}

--- a/src/components/forms/material-form/material-form.js
+++ b/src/components/forms/material-form/material-form.js
@@ -137,9 +137,16 @@ function MaterialForm({ material, id }) {
     values
   );
 
+  const eventPreventHandler = (e) => {
+    e.preventDefault();
+  };
+
   return (
     <div className={styles.container}>
-      <form className={styles.materialForm} onSubmit={handleSubmit}>
+      <form
+        className={styles.materialForm}
+        onSubmit={(e) => eventPreventHandler(e)}
+      >
         <Grid item xs={12}>
           <CheckboxOptions options={checkboxes} />
           <ColorsBar
@@ -205,6 +212,7 @@ function MaterialForm({ material, id }) {
               className={styles.saveButton}
               data-cy='save'
               type='submit'
+              onClickHandler={handleSubmit}
               title={config.buttonTitles.SAVE_MATERIAL}
               values={values}
               errors={errors}

--- a/src/components/forms/material-form/tests/material-form.test.js
+++ b/src/components/forms/material-form/tests/material-form.test.js
@@ -91,8 +91,10 @@ describe('Material form tests', () => {
   });
 
   it('Should simulate submit event', () => {
-    wrapper.find('form').props().onSubmit();
-    expect(mockSubmit).toHaveBeenCalledTimes(1);
+    const preventDefault = () => {};
+    const mockedEvent = { preventDefault };
+    wrapper.find('form').props().onSubmit(mockedEvent);
+    expect(mockSubmit).toHaveBeenCalledTimes(0);
   });
 
   it('Should have default props', () => {

--- a/src/components/forms/news-form/news-form.js
+++ b/src/components/forms/news-form/news-form.js
@@ -147,9 +147,13 @@ const NewsForm = ({ id, newsArticle, editMode }) => {
     return value;
   };
 
+  const eventPreventHandler = (e) => {
+    e.preventDefault();
+  };
+
   return (
     <div>
-      <form onSubmit={handleSubmit}>
+      <form onSubmit={(e) => eventPreventHandler(e)}>
         <div className={styles.buttonContainer}>
           <Grid container spacing={2} className={styles.fixedButtons}>
             <Grid item className={styles.button}>
@@ -160,6 +164,7 @@ const NewsForm = ({ id, newsArticle, editMode }) => {
                 className={styles.saveButton}
                 data-cy='save'
                 type='submit'
+                onClickHandler={handleSubmit}
                 title={SAVE_TITLE}
                 values={checkValidData(values)}
               />

--- a/src/components/forms/pattern-form/pattern-form.js
+++ b/src/components/forms/pattern-form/pattern-form.js
@@ -207,12 +207,16 @@ const PatternForm = ({ pattern, id, isEdit }) => {
     values
   );
 
+  const eventPreventHandler = (e) => {
+    e.preventDefault();
+  };
+
   return (
     <div>
       {loading ? (
         <LoadingBar />
       ) : (
-        <form onSubmit={handleSubmit}>
+        <form onSubmit={(e) => eventPreventHandler(e)}>
           <CheckboxOptions options={checkboxes} />
 
           <Grid item xs={12}>
@@ -292,6 +296,7 @@ const PatternForm = ({ pattern, id, isEdit }) => {
             className={styles.saveButton}
             data-cy='save-btn'
             type='submit'
+            onClickHandler={handleSubmit}
             title={SAVE_TITLE}
             values={values}
             errors={errors}

--- a/src/components/forms/size-form/size-form.js
+++ b/src/components/forms/size-form/size-form.js
@@ -70,6 +70,10 @@ function SizeForm({ id, size }) {
     }
   ];
 
+  const preventEventHandler = (e) => {
+    e.preventDefault();
+  };
+
   if (loading) {
     return <LoadingBar />;
   }
@@ -83,7 +87,10 @@ function SizeForm({ id, size }) {
           ? config.titles.sizesTitles.sizeEdit
           : config.titles.sizesTitles.sizeAdd}
       </Typography>
-      <form className={styles.sizeForm} onSubmit={handleSubmit}>
+      <form
+        className={styles.sizeForm}
+        onSubmit={(e) => preventEventHandler(e)}
+      >
         <Grid item xs={12}>
           <div className={styles.wrapper}>
             <div className={styles.contentWrapper}>
@@ -195,6 +202,7 @@ function SizeForm({ id, size }) {
         <div className={styles.buttonsWrapper}>
           <BackButton initial={!valueEquality} pathBack={pathToSizes} />
           <SaveButton
+            onClickHandler={handleSubmit}
             className={styles.saveButton}
             data-cy={materialUiConstants.save}
             type={materialUiConstants.types.submit}

--- a/src/pages/pattern/tests/__snapshots__/pattern-page.test.js.snap
+++ b/src/pages/pattern/tests/__snapshots__/pattern-page.test.js.snap
@@ -40,6 +40,7 @@ exports[`Pattern-page render tests Should render pattern-page 1`] = `
   <div>
     <FilterNavbar
       clearOptions={Object {}}
+      filterByMultipleOptions={Object {}}
       options={
         Object {
           "clearOptions": Object {

--- a/src/redux/categories/categories.sagas.js
+++ b/src/redux/categories/categories.sagas.js
@@ -105,6 +105,7 @@ export function* handleCategoryUpdate({ payload }) {
     const category = yield call(updateCategory, payload);
 
     if (category) {
+      yield put(setCategoryLoading(false));
       yield call(handleSuccessSnackbar, SUCCESS_UPDATE_STATUS);
       yield put(push(config.routes.pathToCategories));
     }

--- a/src/redux/contact/contact.reducer.js
+++ b/src/redux/contact/contact.reducer.js
@@ -10,7 +10,7 @@ import {
 
 export const selectContact = ({ Contact }) => ({
   contacts: Contact.contacts,
-  loading: Contact.ContactLoading,
+  loading: Contact.contactsLoading,
   contact: Contact.contact
 });
 

--- a/src/redux/header/header.sagas.js
+++ b/src/redux/header/header.sagas.js
@@ -103,6 +103,7 @@ export function* handleHeaderUpdate({ payload }) {
 
     if (header) {
       yield call(handleSuccessSnackbar, SUCCESS_UPDATE_STATUS);
+      yield put(setHeaderLoading(false));
       yield put(push(routes.pathToHeaders));
     }
   } catch (error) {


### PR DESCRIPTION
## Description

Fixed the order of how updating and creating objects to the database works. Previously, the modal window was incorrectly opened at the time object was being added to the database while asking the permission that didn't really matter, as it didn't affect anything, because an object was added anyway. Now it works completely different, because modal shows up before objects are added or updated in the database, so now it acts as intended with a logical approach to user experience.



#### Screenshots

Original             |  Updated
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/53963530/124361160-56f25980-dc36-11eb-920f-dce056f48110.png)  |  ![image](https://user-images.githubusercontent.com/53963530/124361158-52c63c00-dc36-11eb-99d4-54d88071e325.png)

![image](https://user-images.githubusercontent.com/53963530/124361186-77baaf00-dc36-11eb-8527-2aa55bcb6ed7.png)

As we can see it only either updated or creates objects after asking the permission of the user if it was the desired action. 
Also, it is worth noticing that I changed the placement of buttons on the modal, because previously they were placed in the wrong order, which was kind of misleading for users to navigate, so with the provided solution now it looks exactly as described in the linked issue.

### Checklist
- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅ All tests passed locally
- [x] ✨ My changes working with up-to-date front-end and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
