### PR TITLE
Fixed create color on materials page

### DIFF
--- a/src/components/create-color/create-color.js
+++ b/src/components/create-color/create-color.js
@@ -20,7 +20,11 @@ const {
   MAX_LENGTH_MESSAGE,
   MIN_LENGTH_MESSAGE,
   COLOR_VALIDATION_ERROR,
-  VALIDATION_ERROR
+  VALIDATION_ERROR,
+  NOT_UA_NAME_MESSAGE,
+  NOT_EN_NAME_MESSAGE,
+  NOT_EN_SIMPLE_NAME_MESSAGE,
+  NOT_UA_SIMPLE_NAME_MESSAGE
 } = colorErrorMessages;
 const { CREATE_COLOR_TITLE } = buttonTitles;
 
@@ -39,18 +43,22 @@ const CreateColor = () => {
     uaName: Yup.string()
       .min(2, MIN_LENGTH_MESSAGE)
       .max(100, MAX_LENGTH_MESSAGE)
+      .matches(config.formRegExp.uaNameCreation, NOT_UA_NAME_MESSAGE)
       .required(VALIDATION_ERROR),
     enName: Yup.string()
       .min(2, MIN_LENGTH_MESSAGE)
       .max(100, MAX_LENGTH_MESSAGE)
+      .matches(config.formRegExp.enNameCreation, NOT_EN_NAME_MESSAGE)
       .required(VALIDATION_ERROR),
     uaSimpleName: Yup.string()
       .min(2, MIN_LENGTH_MESSAGE)
       .max(100, MAX_LENGTH_MESSAGE)
+      .matches(config.formRegExp.uaNameCreation, NOT_UA_SIMPLE_NAME_MESSAGE)
       .required(VALIDATION_ERROR),
     enSimpleName: Yup.string()
       .min(2, MIN_LENGTH_MESSAGE)
       .max(100, MAX_LENGTH_MESSAGE)
+      .matches(config.formRegExp.enNameCreation, NOT_EN_SIMPLE_NAME_MESSAGE)
       .required(VALIDATION_ERROR),
     colorHex: Yup.string()
       .matches(config.formRegExp.hexString, COLOR_VALIDATION_ERROR)
@@ -71,7 +79,8 @@ const CreateColor = () => {
     errors,
     touched,
     setFieldValue,
-    resetForm
+    resetForm,
+    handleBlur
   } = useFormik({
     validationSchema: formSchema,
     validateOnBlur: true,
@@ -106,6 +115,7 @@ const CreateColor = () => {
           multiline
           value={values[`${lang}Name`]}
           onChange={handleChange}
+          onBlur={handleBlur}
         />
         {touched[`${lang}Name`] && errors[`${lang}Name`] && (
           <div className={styles.inputError}>{errors[`${lang}Name`]}</div>
@@ -120,6 +130,7 @@ const CreateColor = () => {
           error={touched[`${lang}SimpleName`] && !!errors[`${lang}SimpleName`]}
           value={values[`${lang}SimpleName`]}
           onChange={handleChange}
+          onBlur={handleBlur}
         />
         {touched[`${lang}SimpleName`] && errors[`${lang}SimpleName`] && (
           <div className={styles.inputError}>{errors[`${lang}SimpleName`]}</div>
@@ -165,6 +176,7 @@ const CreateColor = () => {
                 setColorPicker(true);
               }}
               onChange={handleChange}
+              onBlur={handleBlur}
             />
             <ColorCircle color={values.colorHex} size={DEFAULT_CIRCLE} />
           </div>
@@ -203,13 +215,14 @@ const CreateColor = () => {
             </AppBar>
             {tabPanels}
           </div>
-
           <div>
             <SaveButton
               className={styles.saveButton}
               data-cy='open-dialog'
               type='submit'
               title={CREATE_COLOR_TITLE}
+              values={values}
+              errors={errors}
             />
           </div>
         </form>

--- a/src/configs/error-messages.js
+++ b/src/configs/error-messages.js
@@ -164,8 +164,8 @@ export const colorErrorMessages = {
   VALIDATION_ERROR: 'Поле обовязкове',
   NOT_EN_NAME_MESSAGE: `Поле може містити тільки англійські літери та цифри`,
   NOT_UA_NAME_MESSAGE: `Поле може містити тільки українські літери та цифри`,
-  NOT_EN_SIMPLE_NAME_MESSAGE: `Введіть опис матеріалу англійською`,
-  NOT_UA_SIMPLE_NAME_MESSAGE: `Введіть опис матеріалу українською`
+  NOT_EN_SIMPLE_NAME_MESSAGE: `Введіть просту назву кольору англійською`,
+  NOT_UA_SIMPLE_NAME_MESSAGE: `Введіть просту назву кольору українською`
 };
 export const statsErrorMessages = {
   NO_STATS: 'Статистика для вибраного значення відсутня'

--- a/src/configs/error-messages.js
+++ b/src/configs/error-messages.js
@@ -161,7 +161,11 @@ export const colorErrorMessages = {
   MAX_LENGTH_MESSAGE: `Не більше 100 символів`,
   MIN_LENGTH_MESSAGE: `Не менше 2 символів`,
   COLOR_VALIDATION_ERROR: 'Неправильний формат кольору',
-  VALIDATION_ERROR: 'Поле обовязкове'
+  VALIDATION_ERROR: 'Поле обовязкове',
+  NOT_EN_NAME_MESSAGE: `Поле може містити тільки англійські літери та цифри`,
+  NOT_UA_NAME_MESSAGE: `Поле може містити тільки українські літери та цифри`,
+  NOT_EN_SIMPLE_NAME_MESSAGE: `Введіть опис матеріалу англійською`,
+  NOT_UA_SIMPLE_NAME_MESSAGE: `Введіть опис матеріалу українською`
 };
 export const statsErrorMessages = {
   NO_STATS: 'Статистика для вибраного значення відсутня'

--- a/src/configs/error-messages.js
+++ b/src/configs/error-messages.js
@@ -160,8 +160,8 @@ export const sizeErrorMessages = {
 export const colorErrorMessages = {
   MAX_LENGTH_MESSAGE: `Не більше 100 символів`,
   MIN_LENGTH_MESSAGE: `Не менше 2 символів`,
-  COLOR_VALIDATION_ERROR: 'Неправильний формат кольору',
-  VALIDATION_ERROR: 'Поле обовязкове',
+  COLOR_VALIDATION_ERROR: `Неправильний формат кольору`,
+  VALIDATION_ERROR: `Поле обов'язкове`,
   NOT_EN_NAME_MESSAGE: `Поле може містити тільки англійські літери та цифри`,
   NOT_UA_NAME_MESSAGE: `Поле може містити тільки українські літери та цифри`,
   NOT_EN_SIMPLE_NAME_MESSAGE: `Введіть просту назву кольору англійською`,


### PR DESCRIPTION
## Description

#981 
Added: 
- the button "Створити колір" is not active until we create color
- onBlur with hints
- validations

#### Screenshots
![image](https://user-images.githubusercontent.com/62055382/134155849-93477bc0-6fe6-4068-afba-07c817aa8f73.png)

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅ All tests passed locally
- [x] ✨ My changes working with up-to-date front-end and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
