### PR TITLE
Fixed styles when switching to dark theme

### DIFF
--- a/src/components/filter-search-sort/filter-by-date/filter-by-date.styles.js
+++ b/src/components/filter-search-sort/filter-by-date/filter-by-date.styles.js
@@ -49,3 +49,10 @@ export const useStyles = makeStyles((theme) => ({
     }
   }
 }));
+
+export const dateRangePickerStyles = {
+  lightCSS:
+    '.rs-picker-daterange-header, .rs-calendar, .rs-picker-toolbar, a.rs-btn {background: transparent} .rs-calendar-table-cell-content:hover {background: rgb(0 0 0 / 6%)} .rs-btn-default.active {background: transparent !important}',
+  darkCSS:
+    '.rs-picker-daterange-header, .rs-calendar, .rs-picker-toolbar, a.rs-btn {background: #424242; border: none} .rs-calendar-table-cell-content:hover {background: #3f51b5} .rs-btn-default.active {background: #424242 !important}'
+};

--- a/src/components/filter-search-sort/filter-by-date/filter-by-date.styles.js
+++ b/src/components/filter-search-sort/filter-by-date/filter-by-date.styles.js
@@ -52,7 +52,7 @@ export const useStyles = makeStyles((theme) => ({
 
 export const dateRangePickerCustomStyles = {
   lightCSS:
-    '.rs-picker-daterange-header, .rs-calendar, .rs-picker-toolbar, a.rs-btn {background: transparent} .rs-calendar-table-cell-content:hover {background: rgb(0 0 0 / 6%)} .rs-btn-default.active {background: transparent !important}',
+    '.rs-picker-daterange-header, .rs-calendar, .rs-picker-toolbar, a.rs-btn {background: transparent} .rs-calendar-table-cell-content:hover {background: rgb(0 0 0 / 6%)} .rs-btn-default.active {background: transparent !important} .rs-picker-toolbar-option span {color: #3f51b5 !important}',
   darkCSS:
-    '.rs-picker-daterange-header, .rs-calendar, .rs-picker-toolbar, a.rs-btn {background: #424242; border: none} .rs-calendar-table-cell-content:hover {background: #3f51b5} .rs-btn-default.active {background: #424242 !important}'
+    '.rs-picker-daterange-header, .rs-calendar, .rs-picker-toolbar, a.rs-btn {background: #424242; border: none} .rs-calendar-table-cell-content:hover {background: #3f51b5} .rs-btn-default.active {background: #424242 !important} .rs-picker-toolbar-option span {color: #fff !important} .rs-picker-toolbar-option:hover {text-decoration: none}'
 };

--- a/src/components/filter-search-sort/filter-by-date/filter-by-date.styles.js
+++ b/src/components/filter-search-sort/filter-by-date/filter-by-date.styles.js
@@ -54,5 +54,5 @@ export const dateRangePickerCustomStyles = {
   lightCSS:
     '.rs-picker-daterange-header, .rs-calendar, .rs-picker-toolbar, a.rs-btn {background: transparent} .rs-calendar-table-cell-content:hover {background: rgb(0 0 0 / 6%)} .rs-btn-default.active {background: transparent !important} .rs-picker-toolbar-option span {color: #3f51b5 !important}',
   darkCSS:
-    '.rs-picker-daterange-header, .rs-calendar, .rs-picker-toolbar, a.rs-btn {background: #424242; border: none} .rs-calendar-table-cell-content:hover {background: #3f51b5} .rs-btn-default.active {background: #424242 !important} .rs-picker-toolbar-option span {color: #fff !important} .rs-picker-toolbar-option:hover {text-decoration: none}'
+    '.rs-picker-daterange-header, .rs-calendar, .rs-picker-toolbar, a.rs-btn {background: #424242; border: none} .rs-calendar-table-cell-content:hover {background: #3f51b5} .rs-btn-default.active {background: #424242 !important} .rs-picker-toolbar-option span {color: #ffffff !important} .rs-picker-toolbar-option:hover {text-decoration: none}'
 };

--- a/src/components/filter-search-sort/filter-by-date/filter-by-date.styles.js
+++ b/src/components/filter-search-sort/filter-by-date/filter-by-date.styles.js
@@ -50,7 +50,7 @@ export const useStyles = makeStyles((theme) => ({
   }
 }));
 
-export const dateRangePickerStyles = {
+export const dateRangePickerCustomStyles = {
   lightCSS:
     '.rs-picker-daterange-header, .rs-calendar, .rs-picker-toolbar, a.rs-btn {background: transparent} .rs-calendar-table-cell-content:hover {background: rgb(0 0 0 / 6%)} .rs-btn-default.active {background: transparent !important}',
   darkCSS:

--- a/src/components/nav-bar/nav-bar.js
+++ b/src/components/nav-bar/nav-bar.js
@@ -23,6 +23,8 @@ import { closeDialog } from '../../redux/dialog-window/dialog-window.actions';
 import useSuccessSnackbar from '../../utils/use-success-snackbar';
 import routes from '../../configs/routes';
 
+import { dateRangePickerStyles } from '../filter-search-sort/filter-by-date/filter-by-date.styles';
+
 const { title } = config.app;
 const { LOGOUT_TITLE } = config.buttonTitles;
 const { LOGOUT_MESSAGE } = config.messages;
@@ -70,25 +72,19 @@ const NavBar = () => {
 
   const urlPage = window.location.pathname;
 
-  const lightCSS =
-    '.rs-picker-daterange-header, .rs-calendar, .rs-picker-toolbar, a.rs-btn {background: transparent} .rs-calendar-table-cell-content:hover {background: rgb(0 0 0 / 6%)} .rs-btn-default.active {background: transparent !important}';
-  const darkCSS =
-    '.rs-picker-daterange-header, .rs-calendar, .rs-picker-toolbar, a.rs-btn {background: #424242; border: none} .rs-calendar-table-cell-content:hover {background: #3f51b5} .rs-btn-default.active {background: #424242 !important}';
-
   const sheet = document.createElement('style');
-  if (darkMode) {
-    sheet.innerHTML = darkCSS;
-  } else {
-    sheet.innerHTML = lightCSS;
-  }
+
+  const checkTheme = () => {
+    if (darkMode) {
+      sheet.innerHTML = dateRangePickerStyles.darkCSS;
+    } else {
+      sheet.innerHTML = dateRangePickerStyles.lightCSS;
+    }
+  };
   document.body.appendChild(sheet);
 
   useEffect(() => {
-    if (darkMode) {
-      sheet.innerHTML = darkCSS;
-    } else {
-      sheet.innerHTML = lightCSS;
-    }
+    checkTheme();
   }, [darkMode]);
 
   return (

--- a/src/components/nav-bar/nav-bar.js
+++ b/src/components/nav-bar/nav-bar.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
 import { Toolbar, AppBar, Typography, IconButton } from '@material-ui/core';
@@ -69,6 +69,27 @@ const NavBar = () => {
   );
 
   const urlPage = window.location.pathname;
+
+  const lightCSS =
+    '.rs-picker-daterange-header, .rs-calendar, .rs-picker-toolbar, a.rs-btn {background: transparent} .rs-calendar-table-cell-content:hover {background: rgb(0 0 0 / 6%)} .rs-btn-default.active {background: transparent !important}';
+  const darkCSS =
+    '.rs-picker-daterange-header, .rs-calendar, .rs-picker-toolbar, a.rs-btn {background: #424242; border: none} .rs-calendar-table-cell-content:hover {background: #3f51b5} .rs-btn-default.active {background: #424242 !important}';
+
+  const sheet = document.createElement('style');
+  if (darkMode) {
+    sheet.innerHTML = darkCSS;
+  } else {
+    sheet.innerHTML = lightCSS;
+  }
+  document.body.appendChild(sheet);
+
+  useEffect(() => {
+    if (darkMode) {
+      sheet.innerHTML = darkCSS;
+    } else {
+      sheet.innerHTML = lightCSS;
+    }
+  }, [darkMode]);
 
   return (
     <AppBar className={classes.appBar}>

--- a/src/components/nav-bar/nav-bar.js
+++ b/src/components/nav-bar/nav-bar.js
@@ -23,7 +23,7 @@ import { closeDialog } from '../../redux/dialog-window/dialog-window.actions';
 import useSuccessSnackbar from '../../utils/use-success-snackbar';
 import routes from '../../configs/routes';
 
-import { dateRangePickerStyles } from '../filter-search-sort/filter-by-date/filter-by-date.styles';
+import { dateRangePickerCustomStyles } from '../filter-search-sort/filter-by-date/filter-by-date.styles';
 
 const { title } = config.app;
 const { LOGOUT_TITLE } = config.buttonTitles;
@@ -74,17 +74,17 @@ const NavBar = () => {
 
   const sheet = document.createElement('style');
 
-  const checkTheme = () => {
+  const changeDateRangePickerStyles = () => {
     if (darkMode) {
-      sheet.innerHTML = dateRangePickerStyles.darkCSS;
+      sheet.innerHTML = dateRangePickerCustomStyles.darkCSS;
     } else {
-      sheet.innerHTML = dateRangePickerStyles.lightCSS;
+      sheet.innerHTML = dateRangePickerCustomStyles.lightCSS;
     }
   };
   document.body.appendChild(sheet);
 
   useEffect(() => {
-    checkTheme();
+    changeDateRangePickerStyles();
   }, [darkMode]);
 
   return (


### PR DESCRIPTION
## Description
Created a custom styles for DateRangePicker component classes when switching theme.


#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| ** ![image](https://user-images.githubusercontent.com/39667486/135456680-00c2badc-6203-4ce7-8878-38e17955ca7c.png) ** | ** ![image](https://user-images.githubusercontent.com/39667486/135456242-62a10e70-51b3-42b7-b18c-5fc380ae447f.png)** |

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅ All tests passed locally
- [x] ✨ My changes working with up-to-date front-end and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
