### PR TITLE
Fix/1087/Save button on news editing page fix

### DIFF
--- a/src/components/forms/news-form/news-form.js
+++ b/src/components/forms/news-form/news-form.js
@@ -88,7 +88,8 @@ const NewsForm = ({ id, newsArticle, editMode }) => {
     handleBlur,
     touched,
     errors,
-    setFieldValue
+    setFieldValue,
+    setValues
   } = useFormik({
     validationSchema: formSchema,
     initialValues: useFormikInitialValues(newsArticle),
@@ -118,10 +119,12 @@ const NewsForm = ({ id, newsArticle, editMode }) => {
 
   const handleLoadAuthorImage = (files) => {
     imageHandler(files, setUploadAuthorImage, values, authorPhoto);
+    setValues(values);
   };
 
   const handleLoadNewsImage = (files) => {
     imageHandler(files, setUploadNewsImage, values, newsImage);
+    setValues(values);
   };
 
   const inputs = [

--- a/src/components/forms/news-form/news-form.js
+++ b/src/components/forms/news-form/news-form.js
@@ -5,6 +5,7 @@ import { Grid, Paper } from '@material-ui/core';
 import * as Yup from 'yup';
 import PropTypes from 'prop-types';
 
+import { red } from '@material-ui/core/colors';
 import { useStyles } from './news-form.styles';
 import { SaveButton, BackButton } from '../../buttons';
 import useNewsHandlers from '../../../utils/use-news-handlers';
@@ -173,8 +174,13 @@ const NewsForm = ({ id, newsArticle, editMode }) => {
           <Paper className={styles.newsItemUpdate}>
             <div className={styles.imageUploadBlock}>
               <div>
-                <span className={styles.imageUpload}>
-                  {config.labels.news.avatarText}
+                <span
+                  className={styles.imageUpload}
+                  style={values.authorPhoto ? {} : { color: red[900] }}
+                >
+                  {values.authorPhoto
+                    ? config.labels.news.avatarText
+                    : `${config.labels.news.avatarText}*`}
                 </span>
 
                 <div className={styles.imageUploadAvatar}>
@@ -192,8 +198,13 @@ const NewsForm = ({ id, newsArticle, editMode }) => {
               </div>
 
               <div>
-                <span className={styles.imageUpload}>
-                  {config.labels.news.mainImgText}
+                <span
+                  className={styles.imageUpload}
+                  style={values.newsImage ? {} : { color: red[900] }}
+                >
+                  {values.newsImage
+                    ? config.labels.news.mainImgText
+                    : `${config.labels.news.mainImgText}*`}
                 </span>
 
                 <div className={styles.imageUploadAvatar}>

--- a/src/components/forms/news-form/tests/news-form.test.js
+++ b/src/components/forms/news-form/tests/news-form.test.js
@@ -35,7 +35,8 @@ jest.mock('formik', () => ({
     handleChange: jest.fn(),
     handleBlur: jest.fn(),
     touched: {},
-    errors: {}
+    errors: {},
+    setValues: jest.fn()
   })
 }));
 


### PR DESCRIPTION
## Description

- Save button on news editing page fixed
- Added highlighting to mandatory photos

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅ All tests passed locally
- [x] ✨ My changes working with up-to-date front-end and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
