### PR TITLE
Feature/1191/add about materials page

### DIFF
--- a/src/components/forms/news-form/news-form.styles.js
+++ b/src/components/forms/news-form/news-form.styles.js
@@ -25,7 +25,10 @@ export const useStyles = makeStyles((theme) => {
     inputBlock: {
       margin: '10px 0'
     },
-
+    textArea: {
+      width: '400px',
+      resize: 'none'
+    },
     formContainer: {
       width: '100%',
       padding: 20,

--- a/src/components/nav-menu/tests/nav-menu.spec.js
+++ b/src/components/nav-menu/tests/nav-menu.spec.js
@@ -90,22 +90,22 @@ describe('Nav menu test', () => {
   });
 
   it('Should render ExpandLess when click on Каталог', () => {
-    wrapper.find(ListItem).at(7).invoke('onClick')();
-    expect(wrapper.exists(ExpandLess)).toBe(true);
-  });
-
-  it('Should render ExpandLess when click on Сертифікати', () => {
     wrapper.find(ListItem).at(8).invoke('onClick')();
     expect(wrapper.exists(ExpandLess)).toBe(true);
   });
 
-  it('Should render ExpandLess when click on Конструктор', () => {
+  it('Should render ExpandLess when click on Сертифікати', () => {
     wrapper.find(ListItem).at(9).invoke('onClick')();
     expect(wrapper.exists(ExpandLess)).toBe(true);
   });
 
-  it('Should render ExpandLess when click on Статичні сторінки', () => {
+  it('Should render ExpandLess when click on Конструктор', () => {
     wrapper.find(ListItem).at(10).invoke('onClick')();
+    expect(wrapper.exists(ExpandLess)).toBe(true);
+  });
+
+  it('Should render ExpandLess when click on Статичні сторінки', () => {
+    wrapper.find(ListItem).at(11).invoke('onClick')();
     expect(wrapper.exists(ExpandLess)).toBe(true);
   });
 

--- a/src/components/nav-menu/tests/nav-menu.spec.js
+++ b/src/components/nav-menu/tests/nav-menu.spec.js
@@ -85,27 +85,27 @@ describe('Nav menu test', () => {
   });
 
   it('Should render ExpandLess when click on Клієнти', () => {
-    wrapper.find(ListItem).at(7).invoke('onClick')();
-    expect(wrapper.exists(ExpandLess)).toBe(true);
-  });
-
-  it('Should render ExpandLess when click on Каталог', () => {
     wrapper.find(ListItem).at(8).invoke('onClick')();
     expect(wrapper.exists(ExpandLess)).toBe(true);
   });
 
-  it('Should render ExpandLess when click on Сертифікати', () => {
+  it('Should render ExpandLess when click on Каталог', () => {
     wrapper.find(ListItem).at(9).invoke('onClick')();
     expect(wrapper.exists(ExpandLess)).toBe(true);
   });
 
-  it('Should render ExpandLess when click on Конструктор', () => {
+  it('Should render ExpandLess when click on Сертифікати', () => {
     wrapper.find(ListItem).at(10).invoke('onClick')();
     expect(wrapper.exists(ExpandLess)).toBe(true);
   });
 
-  it('Should render ExpandLess when click on Статичні сторінки', () => {
+  it('Should render ExpandLess when click on Конструктор', () => {
     wrapper.find(ListItem).at(11).invoke('onClick')();
+    expect(wrapper.exists(ExpandLess)).toBe(true);
+  });
+
+  it('Should render ExpandLess when click on Статичні сторінки', () => {
+    wrapper.find(ListItem).at(12).invoke('onClick')();
     expect(wrapper.exists(ExpandLess)).toBe(true);
   });
 

--- a/src/configs/button-titles.js
+++ b/src/configs/button-titles.js
@@ -6,6 +6,7 @@ const buttonTitles = {
   CREATE_PATTERN_TITLE: 'Додати гобелен',
   CREATE_MODEL_TITLE: 'Додати модель',
   MODEL_SAVE_TITLE: 'Зберегти',
+  CREATE_MATERIAL_TITLE_BLOCK: 'Додати блок матеріалів',
   MODEL_CONSTRUCTOR: 'Конструктор',
   CANCEL_TITLE: 'Ні',
   LOGOUT_TITLE: 'Вихід',

--- a/src/configs/menu-categories.js
+++ b/src/configs/menu-categories.js
@@ -40,7 +40,9 @@ export const menuCategories = [
   ['Останні зміни', routes.pathToHistory, HistoryIcon],
   ['Про Нас', routes.pathToAboutUs, PeopleIcon],
   ['Бізнес сторінки', routes.pathToBusinessPages, BusinessCenterIcon],
-  ['Посилання', routes.pathToHeaders, LinkIcon]
+  ['Посилання', routes.pathToHeaders, LinkIcon],
+  ['Посилання', routes.pathToHeaders, LinkIcon],
+  ['Про матеріали', routes.pathToAboutMaterials, ExtensionIcon]
 ];
 
 export const clientMenuCategories = [

--- a/src/configs/menu-categories.js
+++ b/src/configs/menu-categories.js
@@ -41,7 +41,6 @@ export const menuCategories = [
   ['Про Нас', routes.pathToAboutUs, PeopleIcon],
   ['Бізнес сторінки', routes.pathToBusinessPages, BusinessCenterIcon],
   ['Посилання', routes.pathToHeaders, LinkIcon],
-  ['Посилання', routes.pathToHeaders, LinkIcon],
   ['Про матеріали', routes.pathToAboutMaterials, ExtensionIcon]
 ];
 

--- a/src/configs/routes.js
+++ b/src/configs/routes.js
@@ -57,6 +57,8 @@ const routes = {
   pathToHeaders: '/headers',
   pathToAddHeader: '/headers/add',
   pathToHeaderDetails: '/headers/:id',
+  pathToAboutMaterials: '/about-materials',
+  pathToAddAboutMaterial: '/about-materials/add',
   pathToHomePageSlides: '/home-page-slides',
   pathToAddHomePageSlide: '/home-page-slides/add',
   pathToHomePageSlideDetail: '/home-page-slides/:id',

--- a/src/pages/material/material-about-add.js
+++ b/src/pages/material/material-about-add.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { useCommonStyles } from '../common.styles';
+
+const MaterialAboutAdd = () => {
+  const common = useCommonStyles();
+
+  return <div className={common.container} />;
+};
+
+export default MaterialAboutAdd;

--- a/src/pages/material/material-about.js
+++ b/src/pages/material/material-about.js
@@ -3,7 +3,6 @@ import { Button } from '@material-ui/core';
 import { Link } from 'react-router-dom';
 import { useCommonStyles } from '../common.styles';
 import { config } from '../../configs';
-import materialUiConstants from '../../configs/material-ui-constants';
 import buttonTitles from '../../configs/button-titles';
 
 const { pathToAddAboutMaterial } = config.routes;
@@ -18,8 +17,8 @@ const MaterialAbout = () => {
         id='add-materials'
         component={Link}
         to={pathToAddAboutMaterial}
-        variant={materialUiConstants.outlined}
-        color={materialUiConstants.primary}
+        variant='contained'
+        color='primary'
       >
         {CREATE_MATERIAL_TITLE_BLOCK}
       </Button>

--- a/src/pages/material/material-about.js
+++ b/src/pages/material/material-about.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Button } from '@material-ui/core';
+import { Link } from 'react-router-dom';
+import { useCommonStyles } from '../common.styles';
+import { config } from '../../configs';
+import materialUiConstants from '../../configs/material-ui-constants';
+import buttonTitles from '../../configs/button-titles';
+
+const { pathToAddAboutMaterial } = config.routes;
+const { CREATE_MATERIAL_TITLE_BLOCK } = buttonTitles;
+
+const MaterialAbout = () => {
+  const common = useCommonStyles();
+
+  return (
+    <div className={common.container}>
+      <Button
+        id='add-materials'
+        component={Link}
+        to={pathToAddAboutMaterial}
+        variant={materialUiConstants.outlined}
+        color={materialUiConstants.primary}
+      >
+        {CREATE_MATERIAL_TITLE_BLOCK}
+      </Button>
+    </div>
+  );
+};
+
+export default MaterialAbout;

--- a/src/pages/material/material-about.js
+++ b/src/pages/material/material-about.js
@@ -14,6 +14,7 @@ const MaterialAbout = () => {
   return (
     <div className={common.container}>
       <Button
+        data-testid='createMaterialButton'
         id='add-materials'
         component={Link}
         to={pathToAddAboutMaterial}

--- a/src/pages/material/tests/material-about-add.spec.js
+++ b/src/pages/material/tests/material-about-add.spec.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import MaterialAboutAdd from '../material-about-add';
+
+describe('MaterialAboutAdd should ', () => {
+  it('render', () => {
+    const wrapper = render(
+      <BrowserRouter>
+        <MaterialAboutAdd />
+      </BrowserRouter>
+    );
+    expect(wrapper).toBeDefined();
+  });
+});

--- a/src/pages/material/tests/material-about.spec.js
+++ b/src/pages/material/tests/material-about.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import MaterialAbout from '../material-about';
 
@@ -11,5 +11,15 @@ describe('MaterialAbout should, ', () => {
       </BrowserRouter>
     );
     expect(wrapper).toBeDefined();
+  });
+  it(' render', () => {
+    const { getByTestId } = render(
+      <BrowserRouter>
+        <MaterialAbout />
+      </BrowserRouter>
+    );
+    const form = getByTestId('createMaterialButton');
+    fireEvent.click(form);
+    expect(form).toBeInTheDocument();
   });
 });

--- a/src/pages/material/tests/material-about.spec.js
+++ b/src/pages/material/tests/material-about.spec.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import MaterialAbout from '../material-about';
+
+describe('MaterialAbout should, ', () => {
+  it(' render', () => {
+    const wrapper = render(
+      <BrowserRouter>
+        <MaterialAbout />
+      </BrowserRouter>
+    );
+    expect(wrapper).toBeDefined();
+  });
+});

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -88,6 +88,8 @@ import StrapsEdit from '../pages/straps/straps-edit/straps-edit';
 import UserDetails from '../pages/users/user/user-details';
 import constructorEdit from '../pages/constructor-list/constructor-edit';
 import CreateCertificate from '../pages/certificates/create-certificate/create-certificate';
+import MaterialAbout from '../pages/material/material-about';
+import MaterialAboutAdd from '../pages/material/material-about-add';
 
 const { routes } = config;
 
@@ -155,6 +157,16 @@ const Routes = () => {
             path={routes.pathToAboutUsAdd}
             exact
             component={AboutUsAddBlock}
+          />
+          <Route
+            path={routes.pathToAboutMaterials}
+            exact
+            component={MaterialAbout}
+          />
+          <Route
+            path={routes.pathToAddAboutMaterial}
+            exact
+            component={MaterialAboutAdd}
           />
           <Route
             path={routes.pathToCreateCertificates}


### PR DESCRIPTION
## Description
Add "About Materials" page and routes for this page.

#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| ** original screenshot ** | ** updated screenshot ** |

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅ All tests passed locally
- [x] ✨ My changes working with up-to-date front-end and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
