### PR TITLE
increasing the number of patterns

### DIFF
--- a/src/components/forms/constructor-form/constructor-list-accordion/constructor-list-accordion.js
+++ b/src/components/forms/constructor-form/constructor-list-accordion/constructor-list-accordion.js
@@ -40,7 +40,7 @@ const ConstructorListAccordion = ({ option, expanded, handleChange }) => {
           limit: rowsPerPage,
           skip: currentPage * rowsPerPage
         },
-        limit: rowsPerPage,
+        limit: 20,
         skip: currentPage * rowsPerPage,
         filter
       })


### PR DESCRIPTION
## Description

Go to the constructor tab. List of constructors. Select edit rolltop. Go to the patterns tab. The maximum number of patterns displayed was 10. Now - 20.


### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [ ] ✅ All tests passed locally
- [x] ✨ My changes working with up-to-date front-end and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
