### PR TITLE
Admin: generate certificates button invokes mutation

### DIFF
--- a/src/configs/titles.js
+++ b/src/configs/titles.js
@@ -174,11 +174,11 @@ const titles = {
     validUntil: 'Дійсний до',
     cost: 'Вартість:'
   },
-  certificatesValueTitles: {
-    500: '500 грн',
-    1000: '1000 грн',
-    1500: '1500 грн'
-  }
+  certificatesValueTitles: [
+    { name: '500 грн', value: 500 },
+    { name: '1000 грн', value: 1000 },
+    { name: '1500 грн', value: 1500 }
+  ]
 };
 
 export default titles;

--- a/src/configs/titles.js
+++ b/src/configs/titles.js
@@ -168,14 +168,16 @@ const titles = {
     convertationTitle: 'Відповідна ціна в UAH'
   },
   certificatesTitles: {
-    500: '500 грн',
-    1000: '1000 грн',
-    1500: '1500 грн',
     mainPageTitle: 'Створити Подарунковий Сертифікат:',
     validity: 'Термін дії:',
     validFrom: 'Дійсний від',
     validUntil: 'Дійсний до',
     cost: 'Вартість:'
+  },
+  certificatesValueTitles: {
+    500: '500 грн',
+    1000: '1000 грн',
+    1500: '1500 грн'
   }
 };
 

--- a/src/pages/certificates/certificatesTable/certificateTable.js
+++ b/src/pages/certificates/certificatesTable/certificateTable.js
@@ -25,13 +25,15 @@ export const CertificatesTable = ({ certificates }) => {
     </TableCell>
   ));
 
-  const bodyItems = certificates.map((row) => (
-    <TableRow key={row.id}>
+  const bodyItems = certificates.map((row, index) => (
+    <TableRow key={row.name + index}>
       <TableCell component='th' scope='row'>
-        {row.id}
+        {row.name}
       </TableCell>
-      <TableCell align='left'>{row.name}</TableCell>
-      <TableCell align='left'>{formatDate(row.dateFrom, row.dateTo)}</TableCell>
+      <TableCell align='left'>{row.value} грн</TableCell>
+      <TableCell align='left'>
+        {formatDate(row.dateStart, row.dateEnd)}
+      </TableCell>
     </TableRow>
   ));
 
@@ -48,10 +50,13 @@ export const CertificatesTable = ({ certificates }) => {
 };
 
 const certificateTableInterface = PropTypes.shape({
-  id: PropTypes.string,
   name: PropTypes.string,
-  dateFrom: PropTypes.instanceOf(Date),
-  dateTo: PropTypes.instanceOf(Date)
+  value: PropTypes.number,
+  dateStart: PropTypes.oneOfType([
+    PropTypes.instanceOf(Date),
+    PropTypes.string
+  ]),
+  dateEnd: PropTypes.oneOfType([PropTypes.instanceOf(Date), PropTypes.string])
 });
 
 CertificatesTable.propTypes = {

--- a/src/pages/certificates/create-certificate/create-certificate.js
+++ b/src/pages/certificates/create-certificate/create-certificate.js
@@ -1,4 +1,7 @@
 import React, { useState, useEffect, useMemo } from 'react';
+import { useMutation } from '@apollo/client';
+import { useDispatch } from 'react-redux';
+
 import { DatePicker } from 'rsuite';
 import {
   Grid,
@@ -7,36 +10,90 @@ import {
   TextField,
   Tooltip
 } from '@material-ui/core';
-import { useStyles } from './create-certificate.styles';
-import { BackButton } from '../../../components/buttons';
-import materialUiConstants from '../../../configs/material-ui-constants';
-import { useCommonStyles } from '../../common.styles';
-import CheckBoxes from '../checkBoxes';
+
+import { LOCAL_STORAGE } from '../../../consts/local-storage';
+import { getFromLocalStorage } from '../../../services/local-storage.service';
+
+import {
+  setSnackBarMessage,
+  setSnackBarSeverity,
+  setSnackBarStatus
+} from '../../../redux/snackbar/snackbar.actions';
+import LoadingBar from '../../../components/loading-bar';
+
 import formRegExp from '../../../configs/form-regexp';
-import CertificatesTable from '../certificatesTable';
 import { loginErrorMessages } from '../../../configs/error-messages';
 import buttonTitles from '../../../configs/button-titles';
 import titles from '../../../configs/titles';
 import routes from '../../../configs/routes';
+import materialUiConstants from '../../../configs/material-ui-constants';
+
+import CheckBoxes from '../checkBoxes';
+import { BackButton } from '../../../components/buttons';
+import { useCommonStyles } from '../../common.styles';
+
+import { useStyles } from './create-certificate.styles';
+import CertificatesTable from '../certificatesTable';
+import { bulkGenerateCertificates } from '../operations/certificate.mutation';
 
 const { certificatesTitles } = titles;
 
 const CreateCertificate = () => {
+  const dispatch = useDispatch();
+
   const commonStyles = useCommonStyles();
   const styles = useStyles();
 
   const initialCheckboxes = [
-    { checked: false, quantity: 1, name: certificatesTitles[500] },
-    { checked: false, quantity: 1, name: certificatesTitles[1000] },
-    { checked: false, quantity: 1, name: certificatesTitles[1500] }
+    { checked: false, quantity: 1, name: certificatesTitles[500], value: 500 },
+    {
+      checked: false,
+      quantity: 1,
+      name: certificatesTitles[1000],
+      value: 1000
+    },
+    { checked: false, quantity: 1, name: certificatesTitles[1500], value: 1500 }
   ];
 
   const [checkBoxes, setCheckBoxes] = useState(initialCheckboxes);
+  const [date, setDate] = useState(new Date(new Date().setHours(0, 0, 0, 0)));
+
+  /* 
   const [date, setDate] = useState(new Date());
+  const [date, setDate] = useState('2023-02-04T17:28:59.947Z'); 
+  */
+
   const [email, setEmail] = useState('');
   const [isInvalid, setIsInvalid] = useState(false);
   const [certificates, setCertificates] = useState([]);
   const [disabled, setDisabled] = useState(true);
+
+  const token = getFromLocalStorage(LOCAL_STORAGE.AUTH_ACCESS_TOKEN);
+
+  const [generateCertificates, { loading: certificatesLoading }] = useMutation(
+    bulkGenerateCertificates,
+    {
+      context: {
+        headers: {
+          token
+        }
+      },
+      onCompleted(data) {
+        dispatch(setSnackBarSeverity('success'));
+        dispatch(setSnackBarMessage('Успішно додано'));
+        dispatch(setSnackBarStatus(true));
+
+        setCertificates(data.bulkGenerateCertificates.items);
+        setCheckBoxes(initialCheckboxes);
+        setEmail('');
+      },
+      onError: (err) => {
+        dispatch(setSnackBarSeverity('error'));
+        dispatch(setSnackBarMessage(`Помилка: ${err}`));
+        dispatch(setSnackBarStatus(true));
+      }
+    }
+  );
 
   useEffect(() => {
     let check = false;
@@ -46,7 +103,7 @@ const CreateCertificate = () => {
       }
     });
 
-    if (!isInvalid && date && email && check) {
+    if (!isInvalid && date && check) {
       setDisabled(false);
     } else {
       setDisabled(true);
@@ -60,28 +117,35 @@ const CreateCertificate = () => {
 
     let newDate = new Date(date);
     newDate = newDate.setFullYear(newDate.getFullYear() + 1);
+
     return new Date(newDate);
   }, [date]);
 
   const disabledDate = (pickedDate) => {
     const yesterday = new Date();
     yesterday.setDate(yesterday.getDate() - 1);
-    return pickedDate < yesterday;
+
+    const oneMonthAfter = new Date();
+    oneMonthAfter.setDate(oneMonthAfter.getDate() + 30);
+
+    return pickedDate < yesterday || pickedDate >= oneMonthAfter;
   };
 
-  const createData = (id, name, dateFrom, dateTo) => ({
-    id,
+  const createData = (name, value, dateStart, dateEnd) => ({
     name,
-    dateFrom,
-    dateTo
+    value,
+    dateStart,
+    dateEnd
   });
 
-  const generateCertificates = () => {
+  const emulateCertificates = () => {
     const newArr = [];
     checkBoxes.forEach((certificate) => {
       if (certificate.checked && !isInvalid) {
         for (let i = 0; i < certificate.quantity; i++) {
-          newArr.push(createData('#', certificate.name, date, expireDate));
+          newArr.push(
+            createData('HOR###', certificate.value, date, expireDate)
+          );
         }
       }
     });
@@ -89,8 +153,13 @@ const CreateCertificate = () => {
   };
 
   const emailOnBlur = (e, regExp) => {
-    setIsInvalid(true);
     const input = e.target.value;
+
+    if (!input) {
+      isInvalid && setIsInvalid(false);
+      return;
+    }
+
     input.match(regExp) ? setIsInvalid(false) : setIsInvalid(true);
   };
 
@@ -98,6 +167,24 @@ const CreateCertificate = () => {
     setIsInvalid(true);
     setEmail(e.target.value);
   };
+  const onClickMutation = () =>
+    generateCertificates({
+      variables: {
+        generate: {
+          email,
+          dateStart: date,
+          bulk: checkBoxes.reduce((newArr, item) => {
+            item.checked &&
+              newArr.push({ value: item.value, quantity: item.quantity });
+            return newArr;
+          }, [])
+        }
+      }
+    });
+
+  if (certificatesLoading) {
+    return <LoadingBar />;
+  }
 
   return (
     <div className={styles.container}>
@@ -109,9 +196,11 @@ const CreateCertificate = () => {
           <Tooltip title={!disabled ? '' : 'Згенеруйте сертифікат'}>
             <Grid item className={styles.button}>
               <Button
+                aria-label='bulkGenerate'
                 variant={materialUiConstants.contained}
                 color={materialUiConstants.primary}
-                disabled={!certificates.length}
+                disabled={!(certificates.length && !disabled)}
+                onClick={() => onClickMutation()}
               >
                 {buttonTitles.MODEL_SAVE_TITLE}
               </Button>
@@ -184,10 +273,10 @@ const CreateCertificate = () => {
           </Grid>
           <Grid item xs={6}>
             <Button
-              data-testid='generate'
+              data-testid='emulate'
               variant={materialUiConstants.contained}
               color={materialUiConstants.primary}
-              onClick={generateCertificates}
+              onClick={emulateCertificates}
               disabled={disabled}
             >
               {buttonTitles.GENERATE_CERTIFICATE}

--- a/src/pages/certificates/create-certificate/create-certificate.js
+++ b/src/pages/certificates/create-certificate/create-certificate.js
@@ -12,9 +12,8 @@ import {
 } from '@material-ui/core';
 
 import {
-  setSnackBarMessage,
-  setSnackBarSeverity,
-  setSnackBarStatus
+  showSuccessSnackbar,
+  showErrorSnackbar
 } from '../../../redux/snackbar/snackbar.actions';
 
 import LoadingBar from '../../../components/loading-bar';
@@ -59,18 +58,14 @@ const CreateCertificate = () => {
     bulkGenerateCertificates,
     {
       onCompleted(data) {
-        dispatch(setSnackBarSeverity('success'));
-        dispatch(setSnackBarMessage('Успішно додано'));
-        dispatch(setSnackBarStatus(true));
+        dispatch(showSuccessSnackbar('Успішно додано'));
 
         setCertificates(data.bulkGenerateCertificates.items);
         setCheckBoxes(initialCheckboxes);
         setEmail('');
       },
       onError: (err) => {
-        dispatch(setSnackBarSeverity('error'));
-        dispatch(setSnackBarMessage(`Помилка: ${err}`));
-        dispatch(setSnackBarStatus(true));
+        dispatch(showErrorSnackbar(`Помилка: ${err}`));
       }
     }
   );

--- a/src/pages/certificates/create-certificate/create-certificate.js
+++ b/src/pages/certificates/create-certificate/create-certificate.js
@@ -11,14 +11,12 @@ import {
   Tooltip
 } from '@material-ui/core';
 
-import { LOCAL_STORAGE } from '../../../consts/local-storage';
-import { getFromLocalStorage } from '../../../services/local-storage.service';
-
 import {
   setSnackBarMessage,
   setSnackBarSeverity,
   setSnackBarStatus
 } from '../../../redux/snackbar/snackbar.actions';
+
 import LoadingBar from '../../../components/loading-bar';
 
 import formRegExp from '../../../configs/form-regexp';
@@ -44,12 +42,10 @@ const CreateCertificate = () => {
   const commonStyles = useCommonStyles();
   const styles = useStyles();
 
-  const arrValues = Object.keys(certificatesValueTitles);
-  const initialCheckboxes = arrValues.map((key) => ({
+  const initialCheckboxes = certificatesValueTitles.map((item) => ({
     checked: false,
     quantity: 1,
-    name: certificatesValueTitles[key],
-    value: Number(key)
+    ...item
   }));
 
   const [checkBoxes, setCheckBoxes] = useState(initialCheckboxes);
@@ -59,16 +55,9 @@ const CreateCertificate = () => {
   const [certificates, setCertificates] = useState([]);
   const [disabled, setDisabled] = useState(true);
 
-  const token = getFromLocalStorage(LOCAL_STORAGE.AUTH_ACCESS_TOKEN);
-
   const [generateCertificates, { loading: certificatesLoading }] = useMutation(
     bulkGenerateCertificates,
     {
-      context: {
-        headers: {
-          token
-        }
-      },
       onCompleted(data) {
         dispatch(setSnackBarSeverity('success'));
         dispatch(setSnackBarMessage('Успішно додано'));
@@ -140,9 +129,23 @@ const CreateCertificate = () => {
   };
 
   const emailHandler = (e) => {
-    setIsInvalid(true);
+    setIsInvalid && setIsInvalid(false);
     setEmail(e.target.value);
   };
+
+  useEffect(() => {
+    const timerId = setTimeout(() => {
+      if (email.length > 1) {
+        email.match(formRegExp.email)
+          ? setIsInvalid(false)
+          : setIsInvalid(true);
+      }
+    }, [500]);
+
+    return () => {
+      clearTimeout(timerId);
+    };
+  }, [email]);
 
   const dateResetHours = (dateArg) => {
     const dateObj = dateArg ? new Date(dateArg) : new Date();
@@ -252,6 +255,7 @@ const CreateCertificate = () => {
               className={styles.textField}
               variant={materialUiConstants.outlined}
               label='Email'
+              inputProps={{ 'aria-label': 'email' }}
               value={email}
               helperText={isInvalid && loginErrorMessages.INVALID_EMAIL_MESSAGE}
               onChange={(e) => emailHandler(e)}

--- a/src/pages/certificates/operations/certificate.mutation.js
+++ b/src/pages/certificates/operations/certificate.mutation.js
@@ -1,0 +1,16 @@
+import { gql } from '@apollo/client';
+
+export const bulkGenerateCertificates = gql`
+  mutation ($generate: BulkCertificateInput) {
+    bulkGenerateCertificates(generate: $generate) {
+      ... on CertificateArray {
+        items {
+          name
+          value
+          dateStart
+          dateEnd
+        }
+      }
+    }
+  }
+`;

--- a/src/pages/certificates/tests/create-certificate.spec.js
+++ b/src/pages/certificates/tests/create-certificate.spec.js
@@ -1,11 +1,39 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import CreateCertificate from '../create-certificate';
 
-describe('test CreateCertificate component', () => {
+import { MockedProvider } from '@apollo/client/testing';
+import { useDispatch } from 'react-redux';
+
+import CreateCertificate from '../create-certificate';
+import { mutationVars } from './create-certificate.variables';
+
+jest.mock('react-redux');
+
+jest.mock('../../../services/local-storage.service', () => ({
+  getFromLocalStorage: jest.fn().mockReturnValue(42)
+}));
+
+useDispatch.mockImplementation(() => jest.fn());
+
+describe('test certificates Emulation and Generation', () => {
+
+  /* beforeEach(() => {
+  const mockedDate = new Date('2023-02-04T17:28:59.947Z');
+  jest.spyOn(global, 'Date').mockImplementation(() => mockedDate);
+  console.log(new Date())
+  });
+ */
+  beforeEach(() => {
+    render(
+      <MockedProvider mocks={mutationVars} addTypename={false}>
+        <CreateCertificate />
+      </MockedProvider>
+    );
+  });
+
   it('should change quantity in appropriate h5', () => {
-    const { getAllByRole } = render(<CreateCertificate />);
+    const { getAllByRole } = screen;
     fireEvent.click(getAllByRole('checkbox')[0]);
     const h5 = screen.getByTestId('quantity');
     fireEvent.click(screen.getByTestId('increment'));
@@ -16,16 +44,40 @@ describe('test CreateCertificate component', () => {
   });
 
   it('should render table component', () => {
-    const { getAllByRole } = render(<CreateCertificate />);
+    const { getAllByRole } = screen;
     const input = document.querySelector('.MuiInputBase-input');
 
-    expect(screen.getByTestId('generate')).toHaveAttribute('disabled');
+    expect(screen.getByTestId('emulate')).toHaveAttribute('disabled');
 
     userEvent.click(getAllByRole('checkbox')[0]);
     fireEvent.change(input, { target: { value: 'john.dee@someemail.com' } });
     fireEvent.focusOut(input);
-    userEvent.click(screen.getByTestId('generate'));
+    userEvent.click(screen.getByTestId('emulate'));
 
     expect(screen.getByTestId('table')).toBeInTheDocument();
+    screen.debug(screen.getByTestId('table'));
+  });
+
+  it('button generate should be disabled if there are no emulated certificates', () => {
+    expect(screen.getByRole('button', { name: /bulkGenerate/ })).toBeDisabled();
+  });
+
+  it('should show loader after button generate was clicked', () => {
+    userEvent.click(screen.getAllByRole('checkbox')[0]);
+    userEvent.click(screen.getByTestId('emulate'));
+
+    userEvent.click(screen.getByRole('button', { name: /bulkGenerate/ }));
+
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('should render new table', async () => {
+    userEvent.click(screen.getAllByRole('checkbox')[0]);
+    userEvent.click(screen.getByTestId('emulate'));
+
+    userEvent.click(screen.getByRole('button', { name: /bulkGenerate/ }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(await screen.findByText('HOR123232')).toBeInTheDocument();
   });
 });

--- a/src/pages/certificates/tests/create-certificate.spec.js
+++ b/src/pages/certificates/tests/create-certificate.spec.js
@@ -17,13 +17,6 @@ jest.mock('../../../services/local-storage.service', () => ({
 useDispatch.mockImplementation(() => jest.fn());
 
 describe('test certificates Emulation and Generation', () => {
-
-  /* beforeEach(() => {
-  const mockedDate = new Date('2023-02-04T17:28:59.947Z');
-  jest.spyOn(global, 'Date').mockImplementation(() => mockedDate);
-  console.log(new Date())
-  });
- */
   beforeEach(() => {
     render(
       <MockedProvider mocks={mutationVars} addTypename={false}>
@@ -55,29 +48,28 @@ describe('test certificates Emulation and Generation', () => {
     userEvent.click(screen.getByTestId('emulate'));
 
     expect(screen.getByTestId('table')).toBeInTheDocument();
-    screen.debug(screen.getByTestId('table'));
   });
 
   it('button generate should be disabled if there are no emulated certificates', () => {
     expect(screen.getByRole('button', { name: /bulkGenerate/ })).toBeDisabled();
   });
 
-  it('should show loader after button generate was clicked', () => {
-    userEvent.click(screen.getAllByRole('checkbox')[0]);
-    userEvent.click(screen.getByTestId('emulate'));
+  describe('test Bulk Generation', () => {
+    beforeEach(() => {
+      userEvent.click(screen.getAllByRole('checkbox')[0]);
+      userEvent.click(screen.getByTestId('emulate'));
 
-    userEvent.click(screen.getByRole('button', { name: /bulkGenerate/ }));
+      userEvent.click(screen.getByRole('button', { name: /bulkGenerate/ }));
+    });
 
-    expect(screen.getByRole('progressbar')).toBeInTheDocument();
-  });
+    it('should show loader after button generate was clicked', () => {
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    });
 
-  it('should render new table', async () => {
-    userEvent.click(screen.getAllByRole('checkbox')[0]);
-    userEvent.click(screen.getByTestId('emulate'));
+    it('should render new table', async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
 
-    userEvent.click(screen.getByRole('button', { name: /bulkGenerate/ }));
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
-    expect(await screen.findByText('HOR123232')).toBeInTheDocument();
+      expect(await screen.findByText('HOR123232')).toBeInTheDocument();
+    });
   });
 });

--- a/src/pages/certificates/tests/create-certificate.spec.js
+++ b/src/pages/certificates/tests/create-certificate.spec.js
@@ -10,10 +10,6 @@ import { mutationVars } from './create-certificate.variables';
 
 jest.mock('react-redux');
 
-jest.mock('../../../services/local-storage.service', () => ({
-  getFromLocalStorage: jest.fn().mockReturnValue(42)
-}));
-
 useDispatch.mockImplementation(() => jest.fn());
 
 describe('test certificates Emulation and Generation', () => {
@@ -50,7 +46,7 @@ describe('test certificates Emulation and Generation', () => {
     expect(screen.getByTestId('table')).toBeInTheDocument();
   });
 
-  it('button generate should be disabled if there are no emulated certificates', () => {
+  it('should show disabled button if there are no emulated certificates', () => {
     expect(screen.getByRole('button', { name: /bulkGenerate/ })).toBeDisabled();
   });
 
@@ -70,6 +66,26 @@ describe('test certificates Emulation and Generation', () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
 
       expect(await screen.findByText('HOR123232')).toBeInTheDocument();
+    });
+  });
+
+  describe('timeout for email validation', () => {
+    beforeEach(() => {
+      const input = screen.getByRole('textbox', { name: /email/i });
+      userEvent.type(input, '42');
+    });
+
+    it('should not show error if there are no delay', () => {
+      const errorMessage = screen.queryByText(/Некоректна email адреса/gi);
+
+      expect(errorMessage).not.toBeInTheDocument();
+    });
+
+    it('should show error after >500ms', async () => {
+      await new Promise((resolve) => setTimeout(resolve, 600));
+      const errorMessage = screen.queryByText(/Некоректна email адреса/gi);
+
+      expect(errorMessage).toBeInTheDocument();
     });
   });
 });

--- a/src/pages/certificates/tests/create-certificate.variables.js
+++ b/src/pages/certificates/tests/create-certificate.variables.js
@@ -1,0 +1,55 @@
+import { bulkGenerateCertificates } from '../operations/certificate.mutation.js';
+
+const dateStart = new Date(new Date().setHours(0, 0, 0, 0));
+const requestObj = {
+  query: bulkGenerateCertificates,
+  variables: {
+    generate: {
+      email: '',
+
+      /* dateStart: '2023-02-04T17:28:59.947Z', */
+      dateStart,
+      bulk: [
+        {
+          value: 500,
+          quantity: 1
+        }
+      ]
+    }
+  }
+};
+
+export const mutationVars = [
+  {
+    request: requestObj,
+    result: {
+      data: {
+        bulkGenerateCertificates: {
+          items: [
+            {
+              name: 'HOR123232',
+              value: 1500,
+              dateStart: '2023-02-04T17:28:59.947Z',
+              dateEnd: '2024-02-04T17:28:59.947Z'
+            },
+            {
+              name: 'HOR543216',
+              value: 500,
+              dateStart: '2023-02-04T17:28:59.947Z',
+              dateEnd: '2024-02-04T17:28:59.947Z'
+            }
+          ]
+        }
+      }
+    }
+  }
+];
+
+export const mutationErr = [
+  {
+    request: requestObj,
+    result: {
+      error: new Error('Network error occurred')
+    }
+  }
+];

--- a/src/pages/certificates/tests/create-certificate.variables.js
+++ b/src/pages/certificates/tests/create-certificate.variables.js
@@ -1,13 +1,13 @@
 import { bulkGenerateCertificates } from '../operations/certificate.mutation.js';
 
-const dateStart = new Date(new Date().setHours(0, 0, 0, 0));
+const dateStart = new Date();
+dateStart.setHours(0, 0, 0, 0);
+
 const requestObj = {
   query: bulkGenerateCertificates,
   variables: {
     generate: {
       email: '',
-
-      /* dateStart: '2023-02-04T17:28:59.947Z', */
       dateStart,
       bulk: [
         {


### PR DESCRIPTION
## Description

- [x] imitate generated certificates
- [x] make a query for bulk generation after the button would be pushed save and wait for the response of all generated certificates
- [x] disable button "save" if there is no job to do
![test2](https://user-images.githubusercontent.com/24919819/152771959-4bb1bfac-2c95-4f80-9ae5-7deae96ce089.gif)


https://github.com/ita-social-projects/horondi_admin/issues/1189

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅ All tests passed locally
- [x] ✨ My changes working with up-to-date front-end and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
