### PR TITLE
fix uaNameCreation regexp to properly write color pattern

### DIFF
--- a/src/configs/form-regexp.js
+++ b/src/configs/form-regexp.js
@@ -15,7 +15,7 @@ const formRegExp = {
   userRoles: /(Користувач|Адмін|Суперадмін)/g,
   userStatuses: /(Активний|Неактивний)/g,
   hexString: /^#[0-9a-f]{3,6}$/i,
-  uaNameCreation: /^[а-яїієґa-z0-9\s]+$/gi,
+  uaNameCreation: /^[а-яїієґa-z0-9\s-]+$/gi,
   enNameCreation: /^[a-z0-9\s]+$/gi,
   enDescription: /^[a-z0-9!@#$%^&*)(+=,.:;'"<>`_\-—\s|/\\]+$/gi,
   uaDescription: /^[а-яїієґ0-9!@#$%^&*)(+=,.:;'"<>`_\-—\s|/\\]+$/gi,


### PR DESCRIPTION
## Description

Updated uaNameCreation regexp to be able to rewrite 'Рожево голубий' pattern to 'Рожево-Голубий' in admin.

#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| ![Clip2net_220317173806](https://user-images.githubusercontent.com/49586997/158839468-ba26df4a-cd25-4188-8a7e-f0e2fd58e57c.png) | ![Clip2net_220317173902](https://user-images.githubusercontent.com/49586997/158839684-4c261b57-ead7-44f2-8f66-b2efcb9451f9.png) |

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅ All tests passed locally
- [x] ✨ My changes working with up-to-date front-end and back-end part locally, like charm
- [ ] 🔗 Link pull request to issue
