### PR TITLE
Fix edit button, that opened wrong bottom

### DIFF
--- a/src/pages/bottom/bottom-edit/bottom-edit.js
+++ b/src/pages/bottom/bottom-edit/bottom-edit.js
@@ -6,6 +6,7 @@ import BottomForm from '../../../components/forms/bottom-form';
 import { getBottom } from '../../../redux/bottom/bottom.actions';
 import { useCommonStyles } from '../../common.styles';
 import { bottomSelector } from '../../../redux/selectors/bottom.selectors';
+import LoadingBar from '../../../components/loading-bar';
 
 const BottomEdit = ({ match }) => {
   const { id } = match.params;
@@ -13,11 +14,15 @@ const BottomEdit = ({ match }) => {
   const common = useCommonStyles();
 
   const dispatch = useDispatch();
-  const { bottom } = useSelector(bottomSelector);
+  const { bottom, loading } = useSelector(bottomSelector);
 
   useEffect(() => {
     dispatch(getBottom(id));
   }, [dispatch, id]);
+
+  if (loading) {
+    return <LoadingBar />;
+  }
 
   return (
     <div className={common.detailsContainer}>


### PR DESCRIPTION
## Description

When opening another edit menu in [Constructor: Bottom], the previous data has been shown.

#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| ![Clip2net_220329182315](https://user-images.githubusercontent.com/49586997/160650937-dd3ce1d1-ef53-4065-ae75-7015751c4985.png) | ![Clip2net_220329182839](https://user-images.githubusercontent.com/49586997/160651065-6038c05f-c977-495d-b724-7b94966d397f.png)

### Checklist

- [ ] 🔽 My branch is up-to-date with "development" branch
- [ ] ✅ All tests passed locally
- [ ] ✨ My changes working with up-to-date front-end and back-end part locally, like charm
- [ ] 🔗 Link pull request to issue
