### PR TITLE
Fixed undefined-data, unique keys and colors in StatisticDoughnut

### DIFF
--- a/src/configs/index.js
+++ b/src/configs/index.js
@@ -231,7 +231,10 @@ export const config = {
       colors.green[500],
       colors.red[700],
       colors.amber[600],
-      colors.indigo[500]
+      colors.indigo[500],
+      colors.lime[600],
+      colors.purple[900],
+      colors.red[300]
     ],
     initialValues: {
       names: [],

--- a/src/configs/titles.js
+++ b/src/configs/titles.js
@@ -113,9 +113,13 @@ const titles = {
     mainPageTitle: 'Статистика',
     dateSortTitle: 'Сортувати за датою',
     statuses: {
-      DELIVERED: 'Відправлені',
-      CANCELLED: 'Відхилені',
-      CREATED: 'Створені'
+      CREATED: 'Створені',
+      DELIVERED: 'Доставлені',
+      CONFIRMED: 'Підтверджені',
+      CANCELLED: 'Скасовані',
+      REFUNDED: 'Повернені',
+      PRODUCED: 'Виготовлені',
+      SENT: 'Відправлені'
     }
   },
   orderTitles: {

--- a/src/pages/statistic/statistic-doughnut/legends-list/legends-list.js
+++ b/src/pages/statistic/statistic-doughnut/legends-list/legends-list.js
@@ -13,7 +13,7 @@ const LegendsList = ({ options, labels }) => {
     <div className={styles.root}>
       <Box display='flex' justifyContent='center' mt={2}>
         {options.map((relation, idx) => (
-          <Box key={relation} p={1} textAlign='center'>
+          <Box key={labels[idx]} p={1} textAlign='center'>
             <Typography
               data-cy='doughnut-legent-name'
               color='textPrimary'


### PR DESCRIPTION
## Description

1. Added statistics labels , colors .
2. Fixed bug which arose because of the same values of key property in statistic items.

#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| ![image](https://user-images.githubusercontent.com/59802802/161812352-681ffdf7-292e-430c-8c8b-9b84d27f536e.png) | ![image](https://user-images.githubusercontent.com/59802802/161811914-41436293-f2b9-4310-afe9-67d982706640.png) |

Items with the same key.
![image](https://user-images.githubusercontent.com/59802802/161810404-a8159496-dcbd-4d3f-a0a2-96340207aad9.png)
### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅ All tests passed locally
- [x] ✨ My changes working with up-to-date front-end and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
