### PR TITLE
added status 'Planned' to promocodes

### DIFF
--- a/src/configs/orders.js
+++ b/src/configs/orders.js
@@ -95,7 +95,8 @@ const orders = {
   promoCodesConsts: {
     status: {
       active: 'Активний',
-      expired: 'Завершений'
+      expired: 'Завершений',
+      planned: 'Запланований'
     },
     deletePromo: 'Ви впевнені, що хочете видалити цeй промокод?',
     namePromo: 'Назва промокоду',

--- a/src/pages/promo-code/promo-code-page.js
+++ b/src/pages/promo-code/promo-code-page.js
@@ -49,10 +49,18 @@ const PromoCodePage = () => {
       .split(' ')
       .join('-');
 
-  const checkPromoStatus = (dateTo) =>
-    dateToday < new Date(dateTo)
-      ? promoCodesConsts.status.active
-      : promoCodesConsts.status.expired;
+  const checkPromoStatus = (dateFrom, dateTo) => {
+    const startDate = new Date(dateFrom);
+    const expiredDate = new Date(dateTo);
+
+    if (dateToday < startDate) {
+      return promoCodesConsts.status.planned;
+    }
+    if (dateToday < expiredDate) {
+      return promoCodesConsts.status.active;
+    }
+    return promoCodesConsts.status.expired;
+  };
 
   const completeDeleteHandler = (promoID) => {
     deletePromoCodeByIDMutation({
@@ -83,7 +91,7 @@ const PromoCodePage = () => {
           key={_id}
           promo={code}
           discount={`${discount}%`}
-          status={checkPromoStatus(dateTo)}
+          status={checkPromoStatus(dateFrom, dateTo)}
           showAvatar={false}
           date={`${dateCorrectFormat(dateFrom)} - ${dateCorrectFormat(dateTo)}`}
           deleteHandler={() => openDeleteModalHandler(_id)}

--- a/src/pages/promo-code/tests/promo-code-page.variables.js
+++ b/src/pages/promo-code/tests/promo-code-page.variables.js
@@ -14,6 +14,20 @@ const promoCodes = {
         dateTo: '2021-12-30T23:20:26.887Z',
         discount: 17,
         code: 'test'
+      },
+      {
+        _id: '620d6d413d2dd60025f36809',
+        dateFrom: '2021-12-26T23:20:26.880Z',
+        dateTo: '2025-12-30T23:20:26.887Z',
+        discount: 10,
+        code: 'whatever'
+      },
+      {
+        _id: '6214cbfd9d4b6a00258a2e33',
+        dateFrom: '2025-12-26T23:20:26.880Z',
+        dateTo: '2030-12-30T23:20:26.887Z',
+        discount: 15,
+        code: 'promocode'
       }
     ]
   }


### PR DESCRIPTION
## Description

Promocode had only two statuses: active and expired. However, if promocode had start date after current date(now) there was no correspondent status to it. I fixed that, adding 'Planned' status to promocodes

#### Screenshots

Original
 ![image](https://user-images.githubusercontent.com/84774115/162189436-7969463f-8630-4e8c-b51f-84cca0b9ac6a.png) 
Updated
 ![image](https://user-images.githubusercontent.com/84774115/162189255-d04d7f23-0bc1-4eed-9e30-6e0cb2f0d478.png)

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅ All tests passed locally
- [x] ✨ My changes working with up-to-date front-end and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
