### PR TITLE
Wrong input validation on promocode creation.

### DIFF
--- a/src/configs/error-messages.js
+++ b/src/configs/error-messages.js
@@ -49,7 +49,8 @@ export const promoCodeErrorMessages = {
   STYLE_CODE: 'Поле має містити англійські літери або цифри',
   ERROR_MESSAGE: 'Поле має бути заповнене',
   LENGTH_DISCOUNT: 'Поле має містити максимально 2 цифри',
-  STYLE_DISCOUNT: 'Поле має містити цифри'
+  POSITIVE_DISCOUNT: 'Тільки більше нуля',
+  MULTIPLE_DISCOUNT: 'Число має бути кратним п’яти'
 };
 
 export const patternErrorMessages = {

--- a/src/configs/form-regexp.js
+++ b/src/configs/form-regexp.js
@@ -27,6 +27,7 @@ const formRegExp = {
   pageCode: /^[a-z0-9|-]/i,
   postCode: /^\d{5}(?:[-\\s]\\d{4})?$/,
   promoCodeName: /[a-z]{2,}\w*/i,
-  promoCodeDiscount: /\d{1,2}/
+  promoCodeDiscountMultiple: /^\d*[05]$/,
+  promoCodeDiscountPositive: /^[1-9][0-9]*$/
 };
 export default formRegExp;

--- a/src/validations/promo-code/promo-code-validation.js
+++ b/src/validations/promo-code/promo-code-validation.js
@@ -7,7 +7,8 @@ const {
   STYLE_CODE,
   ERROR_MESSAGE,
   LENGTH_DISCOUNT,
-  STYLE_DISCOUNT
+  POSITIVE_DISCOUNT,
+  MULTIPLE_DISCOUNT
 } = config.promoCodeErrorMessages;
 
 export const promoValidationSchema = Yup.object().shape({
@@ -21,7 +22,8 @@ export const promoValidationSchema = Yup.object().shape({
   discount: Yup.string()
     .min(1, LENGTH_DISCOUNT)
     .max(2, LENGTH_DISCOUNT)
-    .matches(formRegExp.promoCodeDiscount, STYLE_DISCOUNT)
+    .matches(formRegExp.promoCodeDiscountPositive, POSITIVE_DISCOUNT)
+    .matches(formRegExp.promoCodeDiscountMultiple, MULTIPLE_DISCOUNT)
     .required(ERROR_MESSAGE),
   categories: Yup.array().min(1, ERROR_MESSAGE).required(ERROR_MESSAGE)
 });


### PR DESCRIPTION
## Description

Added validation must have a positive number and a multiple of 5

#### Screenshots


![positive](https://user-images.githubusercontent.com/100776036/163809813-b5c5f345-904a-442d-bbb4-5839da5138d1.png) ![multiple](https://user-images.githubusercontent.com/100776036/163809822-d9c5b9ef-6973-4c8f-8c48-29fe333ce362.png) 

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅ All tests passed locally
- [x] ✨ My changes working with up-to-date front-end and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
