### PR TITLE
[Catalog] Size, Gobelens list appears only after page reload

### DIFF
--- a/src/redux/material/material.sagas.js
+++ b/src/redux/material/material.sagas.js
@@ -53,8 +53,8 @@ export function* handleMaterialsByPurposeLoad() {
 
 export function* handleMaterialsLoad({ payload }) {
   const filter = {
-    ...payload.filters,
-    colors: payload.filters.colors.map((el) => el._id)
+    ...payload.filter,
+    colors: payload.filter.colors.map((el) => el._id)
   };
   try {
     yield put(setMaterialLoading(true));


### PR DESCRIPTION
## Description

Fixed bug on material page

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅ All tests passed locally
- [x] ✨ My changes working with up-to-date front-end and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
