### PR TITLE
remove setFieldValue in worldwide useEffect

### DIFF
--- a/src/pages/order-item/tabs/delivery-details/worldwide/worldwide.js
+++ b/src/pages/order-item/tabs/delivery-details/worldwide/worldwide.js
@@ -79,9 +79,6 @@ const Worldwide = ({ values, handleChange, setFieldValue }) => {
         values.stateOrProvince
       );
     } else {
-      setFieldValue(worldWide.worldWideCity, '');
-      setFieldValue(worldWide.worldWideStreet, '');
-      setFieldValue(worldWide.cityCode, '');
       setCitiesOptions([]);
     }
   }, [values.stateOrProvince]);


### PR DESCRIPTION
## Description

State/province is not required. And when it comes empty from db, now fields lower are not changing.

#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| ![Clip2net_220520094514](https://user-images.githubusercontent.com/49586997/169469318-eb3d1b47-9506-4092-b86e-3dc0f7004ef1.png) | ![Clip2net_220520094554](https://user-images.githubusercontent.com/49586997/169469384-fe4ee7c7-fb13-434b-8599-99d1117330df.png) |

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅ All tests passed locally
- [x] ✨ My changes working with up-to-date front-end and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
