### PR TITLE
make save btn disabled when changes were not yet made

### DIFF
--- a/src/pages/promo-code/promo-code-edit/test/promo-code-edit.spec.js
+++ b/src/pages/promo-code/promo-code-edit/test/promo-code-edit.spec.js
@@ -17,7 +17,8 @@ jest.mock('react-router', () => ({
     id: '61f3ca58fb37d558e8bba8de'
   }),
   useHistory: () => ({
-    push: mockHistoryPush
+    push: mockHistoryPush,
+    block: jest.fn()
   })
 }));
 const history = createMemoryHistory();

--- a/src/pages/promo-code/promo-code-form/promo-code-form.js
+++ b/src/pages/promo-code/promo-code-form/promo-code-form.js
@@ -3,7 +3,6 @@ import { useFormik } from 'formik';
 import { useQuery } from '@apollo/client';
 import { DatePicker } from 'rsuite';
 import {
-  Button,
   Grid,
   TextField,
   Checkbox,
@@ -17,14 +16,12 @@ import { getCategoriesList } from '../operations/categories-list.queries';
 import LoadingBar from '../../../components/loading-bar';
 import { productsTranslations } from '../../../configs/product-translations';
 import orders from '../../../configs/orders';
-import {
-  checkboxesValues,
-  productFormValues
-} from '../../../consts/product-form';
+import { productFormValues } from '../../../consts/product-form';
 
 import { useStyles } from './promo-code-form.style';
 import { useCommonStyles } from '../../common.styles';
-import { BackButton } from '../../../components/buttons';
+import { useUnsavedChangesHandler } from '../../../hooks/form-dialog/use-unsaved-changes-handler';
+import { BackButton, SaveButton } from '../../../components/buttons';
 
 function PromoCodeForm({
   pathToPromoCodesPage,
@@ -64,7 +61,7 @@ function PromoCodeForm({
   }
 
   const {
-    values: { code, dateTo, dateFrom, discount, categories, _id },
+    values,
     handleSubmit,
     handleChange,
     handleBlur,
@@ -88,6 +85,10 @@ function PromoCodeForm({
         }
       }).then(goToPromoPage)
   });
+
+  const unblock = useUnsavedChangesHandler(values);
+
+  const { code, dateTo, dateFrom, discount, categories, _id } = values;
 
   const handlerDateHandler = (value, string) => setFieldValue(string, value);
 
@@ -144,16 +145,14 @@ function PromoCodeForm({
           <BackButton pathBack={pathToPromoCodesPage} />
         </Grid>
         <Grid>
-          <Button
-            id='buttonSave'
-            size='medium'
+          <SaveButton
             type={productFormValues.submit}
-            variant={productFormValues.contained}
-            color={checkboxesValues.primary}
-            onClick={handleSubmit}
-          >
-            {SAVE}
-          </Button>
+            title={SAVE}
+            onClickHandler={handleSubmit}
+            values={values}
+            errors={errors}
+            unblockFunction={unblock}
+          />
         </Grid>
       </div>
 

--- a/src/pages/promo-code/promo-code-form/test/promo-code-form.spec.js
+++ b/src/pages/promo-code/promo-code-form/test/promo-code-form.spec.js
@@ -2,9 +2,14 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { MockedProvider } from '@apollo/client/testing';
+import { useDispatch } from 'react-redux';
 
 import PromoCodeForm from '../promo-code-form';
 import { mocks } from './promo-code-form.variables';
+
+jest.mock('react-redux');
+const dispatch = jest.fn();
+useDispatch.mockImplementation(() => dispatch);
 
 const props = {
   initialState: {


### PR DESCRIPTION
## Description
Save btn was active, when you was entering "Edit promocode" page. Now it's disabled by default, and only when changes are made, is transformed to active

#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| ![image](https://user-images.githubusercontent.com/84774115/173333852-1aeaa729-35e5-40b9-94d1-a08c3a89ccc2.png) | ![image](https://user-images.githubusercontent.com/84774115/173333812-e29a6a41-ebec-4eac-bd9a-8a3bd5ef260a.png) |

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅ All tests passed locally
- [x] ✨ My changes working with up-to-date front-end and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
