### PR TITLE
Promocodes/1376/fixed incorrect menu category name

### DIFF
--- a/src/configs/menu-categories.js
+++ b/src/configs/menu-categories.js
@@ -59,7 +59,7 @@ export const catalogMenuCategories = [
   ['Гобелени', routes.pathToPatterns, GradientIcon]
 ];
 export const promoMenuCategories = [
-  ['Створити промокод', routes.pathToPromoCodes, PromoIcon]
+  ['Інформація про промокоди', routes.pathToPromoCodes, PromoIcon]
 ];
 
 export const staticPagesCategories = [


### PR DESCRIPTION
## Description

fixed incorrect menu category name.

#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| ![image](https://user-images.githubusercontent.com/80908916/174076134-f82ad5f3-7c39-4752-9eb5-fdcae702a101.png) | 
![image](https://user-images.githubusercontent.com/80908916/174076065-b05cf642-54d7-40ab-a9d4-ce87766a8d9c.png)
 |

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅ All tests passed locally
- [x] ✨ My changes working with up-to-date front-end and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
