### PR TITLE
Improvement/1402/document title according to current page

### DIFF
--- a/src/components/forms/product-form/product-form.js
+++ b/src/components/forms/product-form/product-form.js
@@ -180,6 +180,8 @@ const ProductForm = ({ isEdit }) => {
     shouldValidate,
     setShouldValidate,
     values,
+    dirty,
+    isValid,
     errors,
     touched,
     handleSubmit,
@@ -340,6 +342,7 @@ const ProductForm = ({ isEdit }) => {
               values={values}
               errors={errors}
               unblockFunction={unblock}
+              disabled={!dirty || !isValid}
             />
           </Grid>
         </Grid>

--- a/src/components/nav-menu/nav-menu.js
+++ b/src/components/nav-menu/nav-menu.js
@@ -1,4 +1,4 @@
-import React, { useState, Fragment, useEffect, isValidElement } from 'react';
+import React, { useState, Fragment, useEffect } from 'react';
 import { NavLink, useLocation } from 'react-router-dom';
 import {
   Drawer,
@@ -204,24 +204,24 @@ const NavMenu = ({ width }) => {
 
   const parentMenuItems = parentMenuTabsProperties.map(
     ([handleClick, stateMenu, subList, primary, ItemIcon]) => (
-        <Fragment key={primary}>
-          <ListItem
-            button
-            onClick={handleClick}
-            disableGutters
-            className={classes.notNested}
-          >
-            <ListItemIcon>
-              <ItemIcon />
-            </ListItemIcon>
-            <ListItemText primary={primary} />
-            {stateMenu ? <ExpandLess /> : <ExpandMore />}
-          </ListItem>
-          <Collapse in={stateMenu} timeout='auto' unmountOnExit>
-            <List>{subList}</List>
-          </Collapse>
-        </Fragment>
-      )
+      <Fragment key={primary}>
+        <ListItem
+          button
+          onClick={handleClick}
+          disableGutters
+          className={classes.notNested}
+        >
+          <ListItemIcon>
+            <ItemIcon />
+          </ListItemIcon>
+          <ListItemText primary={primary} />
+          {stateMenu ? <ExpandLess /> : <ExpandMore />}
+        </ListItem>
+        <Collapse in={stateMenu} timeout='auto' unmountOnExit>
+          <List>{subList}</List>
+        </Collapse>
+      </Fragment>
+    )
   );
 
   const handleDrawerToggle = () => {

--- a/src/components/nav-menu/nav-menu.js
+++ b/src/components/nav-menu/nav-menu.js
@@ -50,15 +50,8 @@ const allCategories = [
   ...config.certificatesMenuCategories
 ];
 
-const truncateStr = (str = '', maxLength = 11) => {
-  if (str.length > maxLength) {
-    return `${str.slice(0, maxLength).trim()}...`;
-  }
-  return str;
-};
-
 const setDocumentTitle = (newTitle) => {
-  document.title = `Horondi - ${truncateStr(newTitle)}`;
+  document.title = `Horondi - ${newTitle}`;
 };
 
 const NavMenu = ({ width }) => {

--- a/src/components/nav-menu/nav-menu.js
+++ b/src/components/nav-menu/nav-menu.js
@@ -50,20 +50,23 @@ const allCategories = [
   ...config.certificatesMenuCategories
 ];
 
+const truncateStr = (str = '', maxLength = 11) => {
+  if (str.length > maxLength) {
+    return `${str.slice(0, maxLength).trim()}...`;
+  }
+  return str;
+};
+
+const setDocumentTitle = (newTitle) => {
+  document.title = `Horondi - ${truncateStr(newTitle)}`;
+};
+
 const NavMenu = ({ width }) => {
   const classes = useStyles();
   const dispatch = useDispatch();
   const routeLocation = useLocation();
 
   const initialDocumentTitle = config.menuCategories[0][0];
-
-  useEffect(() => {
-    const currentTab = allCategories.find(
-      (category) => category[1] === routeLocation.pathname
-    );
-    document.title =
-      currentTab && currentTab[0] ? currentTab[0] : initialDocumentTitle;
-  }, [routeLocation]);
 
   const staticArray = {
     clientTab: false,
@@ -83,6 +86,15 @@ const NavMenu = ({ width }) => {
       pendingQuestionsCount: EmailQuestions.pendingCount
     })
   );
+
+  useEffect(() => {
+    const currentTab = allCategories.find(
+      (category) => category[1] === routeLocation.pathname
+    );
+    setDocumentTitle(
+      currentTab && currentTab[0] ? currentTab[0] : initialDocumentTitle
+    );
+  }, [routeLocation]);
 
   const returnedList = (pathTitle, pathTo, PathIcon, nested) => (
     <ListItem

--- a/src/components/nav-menu/nav-menu.js
+++ b/src/components/nav-menu/nav-menu.js
@@ -50,10 +50,6 @@ const allCategories = [
   ...config.certificatesMenuCategories
 ];
 
-const setDocumentTitle = (newTitle) => {
-  document.title = `Horondi - ${newTitle}`;
-};
-
 const NavMenu = ({ width }) => {
   const classes = useStyles();
   const dispatch = useDispatch();
@@ -80,6 +76,10 @@ const NavMenu = ({ width }) => {
     })
   );
 
+  const setDocumentTitle = (newTitle) => {
+    document.title = `Horondi - ${newTitle}`;
+  };
+
   useEffect(() => {
     const currentTab = allCategories.find(
       (category) => category[1] === routeLocation.pathname
@@ -87,7 +87,7 @@ const NavMenu = ({ width }) => {
     setDocumentTitle(
       currentTab && currentTab[0] ? currentTab[0] : initialDocumentTitle
     );
-  }, [routeLocation]);
+  }, [routeLocation, initialDocumentTitle]);
 
   const returnedList = (pathTitle, pathTo, PathIcon, nested) => (
     <ListItem

--- a/src/components/nav-menu/nav-menu.js
+++ b/src/components/nav-menu/nav-menu.js
@@ -50,6 +50,10 @@ const allCategories = [
   ...config.certificatesMenuCategories
 ];
 
+const setDocumentTitle = (newTitle) => {
+  document.title = `Horondi - ${newTitle}`;
+};
+
 const NavMenu = ({ width }) => {
   const classes = useStyles();
   const dispatch = useDispatch();
@@ -76,10 +80,6 @@ const NavMenu = ({ width }) => {
     })
   );
 
-  const setDocumentTitle = (newTitle) => {
-    document.title = `Horondi - ${newTitle}`;
-  };
-
   useEffect(() => {
     const currentTab = allCategories.find(
       (category) => category[1] === routeLocation.pathname
@@ -87,7 +87,7 @@ const NavMenu = ({ width }) => {
     setDocumentTitle(
       currentTab && currentTab[0] ? currentTab[0] : initialDocumentTitle
     );
-  }, [routeLocation, initialDocumentTitle]);
+  }, [routeLocation]);
 
   const returnedList = (pathTitle, pathTo, PathIcon, nested) => (
     <ListItem

--- a/src/components/nav-menu/nav-menu.js
+++ b/src/components/nav-menu/nav-menu.js
@@ -1,5 +1,5 @@
-import React, { useState, Fragment } from 'react';
-import { NavLink } from 'react-router-dom';
+import React, { useState, Fragment, useEffect, isValidElement } from 'react';
+import { NavLink, useLocation } from 'react-router-dom';
 import {
   Drawer,
   Divider,
@@ -39,10 +39,31 @@ import {
 import { PromoIcon } from '../nav-bar/icons';
 
 const { titles } = config;
+const allCategories = [
+  ...config.menuCategories,
+  ...config.materialMenuCategories,
+  ...config.clientMenuCategories,
+  ...config.catalogMenuCategories,
+  ...config.promoMenuCategories,
+  ...config.staticPagesCategories,
+  ...config.constructorMenuCategories,
+  ...config.certificatesMenuCategories
+];
 
 const NavMenu = ({ width }) => {
   const classes = useStyles();
   const dispatch = useDispatch();
+  const routeLocation = useLocation();
+
+  const initialDocumentTitle = config.menuCategories[0][0];
+
+  useEffect(() => {
+    const currentTab = allCategories.find(
+      (category) => category[1] === routeLocation.pathname
+    );
+    document.title =
+      currentTab && currentTab[0] ? currentTab[0] : initialDocumentTitle;
+  }, [routeLocation]);
 
   const staticArray = {
     clientTab: false,

--- a/src/hooks/product/use-product-validation.js
+++ b/src/hooks/product/use-product-validation.js
@@ -120,6 +120,8 @@ const useProductValidation = (
 
   const {
     values,
+    dirty,
+    isValid,
     errors,
     touched,
     handleSubmit,
@@ -144,6 +146,8 @@ const useProductValidation = (
     shouldValidate,
     setShouldValidate,
     values,
+    dirty,
+    isValid,
     errors,
     touched,
     handleSubmit,


### PR DESCRIPTION
## Description
The document title of the admin page now gets updated according to the selected tab's name of the navigation menu on the left.

#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| ![2022-06-27_19-10](https://user-images.githubusercontent.com/71522782/175989507-8bbc741e-1f2e-4913-b581-99053c60b286.png) | ![2022-06-27_19-05](https://user-images.githubusercontent.com/71522782/175989630-d5256407-7f65-44ad-b906-efe1fa18cf91.png)|

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅ All tests passed locally
- [x] ✨ My changes working with up-to-date front-end and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
