### PR TITLE
Bugfix/1434/Add order without user

### DIFF
--- a/src/utils/order.js
+++ b/src/utils/order.js
@@ -129,7 +129,7 @@ const items = (order) =>
 export const newOrder = (order) => ({
   status: order.status,
   recipient: order.recipient,
-  user_id: order.user_id,
+  user_id: order.user_id || null,
   delivery: address(order.delivery),
   items: items(order),
   paymentMethod: order.paymentMethod,


### PR DESCRIPTION
## Description

Added a different default value for the `user_id` variable.

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅ All tests passed locally
- [x] ✨ My changes working with up-to-date front-end and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
