### PR TITLE
Bugix/1441/Fix materials query

### DIFF
--- a/src/redux/material/material.operations.js
+++ b/src/redux/material/material.operations.js
@@ -49,7 +49,7 @@ export const getAllMaterialsByPurpose = async (purposes) => {
   const query = `
     query($purposes: [PurposeEnum]) {
       getMaterialsByPurpose(purposes: $purposes) {
-        main {
+        basic {
           _id
           name {
             lang

--- a/src/redux/products/products.operations.js
+++ b/src/redux/products/products.operations.js
@@ -267,8 +267,8 @@ const getProductDetails = async () => {
             }
           }
         }
-        getMaterialsByPurpose(purposes: [MAIN, BOTTOM, INNER, BACK]) {
-          main {
+        getMaterialsByPurpose(purposes: [BASIC, BOTTOM, INNER, BACK]) {
+          basic {
             _id
             name {
               value


### PR DESCRIPTION
## Description

The getMaterialsByPurpose query was modified to fix the errors, which appear on the admin page when fetching for products and models.

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅ All tests passed locally and linter has no warnings and errors
- [x] ✨ My changes working with up-to-date front-end and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
