### PR TITLE
payment status changing and checkbox for card disabled

### DIFF
--- a/src/pages/order-item/order-item.js
+++ b/src/pages/order-item/order-item.js
@@ -43,7 +43,14 @@ const OrderItem = ({ id }) => {
   };
 
   const handleFormSubmit = () => {
-    handleOrderSubmition(dispatch, resetForm, openSuccessSnackbar, values, id);
+    handleOrderSubmition(
+      dispatch,
+      resetForm,
+      openSuccessSnackbar,
+      values,
+      id,
+      selectedOrder
+    );
     setTabValue(0);
   };
 

--- a/src/pages/order-item/tabs/general.js
+++ b/src/pages/order-item/tabs/general.js
@@ -87,6 +87,7 @@ const General = ({ data, handleChange, inputOptions }) => {
           checked={isPaid}
           name={inputName.isPaidInput}
           onChange={handleChange}
+          disabled={paymentMethod === 'CARD'}
         />
       </div>
     </div>

--- a/src/utils/handle-orders-page.js
+++ b/src/utils/handle-orders-page.js
@@ -28,7 +28,8 @@ export const handleOrderSubmition = (
   resetForm,
   openSuccessSnackbar,
   data,
-  id
+  id,
+  selectedOrder
 ) => {
   if (
     newOrder(data).status !== initialValues.status &&
@@ -48,7 +49,11 @@ export const handleOrderSubmition = (
       openSuccessSnackbar(updateOrderSnackbar, dialogContent, buttonTitle);
     }, 0);
   } else if (id) {
-    dispatch(updateOrder(newOrder(data), id));
+    const dataWithSelectedOrder = {
+      ...data,
+      paymentStatus: selectedOrder.paymentStatus
+    };
+    dispatch(updateOrder(newOrder(dataWithSelectedOrder), id));
   } else {
     dispatch(addOrder(newOrder(data)));
     resetForm({ values: initialValues });

--- a/src/utils/order.js
+++ b/src/utils/order.js
@@ -139,7 +139,7 @@ export const newOrder = (order) => ({
   paymentStatus: paymentStatusTransfer(order.isPaid, order.paymentStatus)
 });
 
-const paymentStatusTransfer = (isPaid, paymentStatus) =>
+export const paymentStatusTransfer = (isPaid, paymentStatus) =>
   isPaid ? 'PAID' : paymentStatus || 'CREATED';
 
 export const submitStatus = ['CREATED', 'CONFIRMED'];

--- a/src/utils/order.js
+++ b/src/utils/order.js
@@ -135,8 +135,12 @@ export const newOrder = (order) => ({
   paymentMethod: order.paymentMethod,
   userComment: order.userComment,
   isPaid: order.isPaid,
-  promoCodeId: order.promoCodeId
+  promoCodeId: order.promoCodeId,
+  paymentStatus: paymentStatusTransfer(order.isPaid, order.paymentStatus)
 });
+
+const paymentStatusTransfer = (isPaid, paymentStatus) =>
+  isPaid ? 'PAID' : paymentStatus || 'CREATED';
 
 export const submitStatus = ['CREATED', 'CONFIRMED'];
 

--- a/src/utils/order.js
+++ b/src/utils/order.js
@@ -139,7 +139,7 @@ export const newOrder = (order) => ({
   paymentStatus: paymentStatusTransfer(order.isPaid, order.paymentStatus)
 });
 
-export const paymentStatusTransfer = (isPaid, paymentStatus) =>
+export const paymentStatusTransfer = (isPaid, paymentStatus = null) =>
   isPaid ? 'PAID' : paymentStatus || 'CREATED';
 
 export const submitStatus = ['CREATED', 'CONFIRMED'];

--- a/src/utils/tests/order.test.js
+++ b/src/utils/tests/order.test.js
@@ -4,7 +4,9 @@ import {
   setFormValues,
   calculateItemsPriceWithDiscount,
   calculateDiscountsForProducts,
-  mergeProducts
+  mergeProducts,
+  paymentStatusTransfer,
+  newOrder
 } from '../order';
 import {
   deliveryMock,
@@ -20,7 +22,10 @@ import {
   mockItemsDiscount,
   mockItemsPriceWithDiscount,
   modelMock,
-  orderWithExistedItemsMock
+  orderWithExistedItemsMock,
+  worldWideWithDataMock,
+  novaPostWithDataMock,
+  newOrderMock
 } from './order.variables';
 
 const setFieldValue = jest.fn();
@@ -42,11 +47,20 @@ describe('[utils:order]', () => {
   });
 
   it('setFormValues function - novaPost type', () => {
-    const { delivery, paymentMethod } = setFormValues(setFormMock);
+    const { delivery, paymentMethod } = setFormValues(setFormMock('novaPost'));
 
     expect(paymentMethod).toBe('CARD');
     expect(delivery.courier).toEqual(courierMock);
+    expect(delivery.novaPost).toEqual(novaPostWithDataMock);
     expect(delivery.ukrPost).toEqual(ukrPostMock);
+  });
+
+  it('setFormValues function - worldWide type', () => {
+    const { delivery, paymentMethod } = setFormValues(setFormMock('worldWide'));
+
+    expect(paymentMethod).toBe('CARD');
+    expect(delivery.courier).toEqual(courierMock);
+    expect(delivery.worldWide).toEqual(worldWideWithDataMock);
   });
 
   it('calculateItemsPriceWithDiscount function', () => {
@@ -113,5 +127,23 @@ describe('[utils:order]', () => {
 
     productsMock[1].quantity = 6;
     expect(result).toEqual(productsMock);
+  });
+
+  it('Payment status is paid', () => {
+    const result = paymentStatusTransfer(true, 'CREATED');
+
+    expect(result).toBe('PAID');
+  });
+
+  it('Payment status is in progress', () => {
+    const result = paymentStatusTransfer(false, 'PROCESSING');
+
+    expect(result).toBe('PROCESSING');
+  });
+
+  it('Create new order', () => {
+    const result = newOrder(setFormMock('newOrder'));
+
+    expect(result).toStrictEqual(newOrderMock);
   });
 });

--- a/src/utils/tests/order.variables.js
+++ b/src/utils/tests/order.variables.js
@@ -2,7 +2,7 @@ import config from '../../configs/orders';
 
 const { deliveryTypes } = config;
 
-export const worldWideMock = {
+export const worldWideWithDataMock = {
   messenger: 'Telegram',
   messengerPhone: '0987654321',
   worldWideCountry: 'Ukraine',
@@ -12,9 +12,24 @@ export const worldWideMock = {
   cityCode: '68789'
 };
 
-export const novaPostMock = {
+export const novaPostWithDataMock = {
   city: 'Lviv',
   courierOffice: 'office 42'
+};
+
+export const worldWideMock = {
+  messenger: '',
+  messengerPhone: '',
+  worldWideCountry: '',
+  stateOrProvince: '',
+  worldWideCity: '',
+  worldWideStreet: '',
+  cityCode: ''
+};
+
+export const novaPostMock = {
+  city: '',
+  courierOffice: ''
 };
 
 export const ukrPostMock = {
@@ -39,7 +54,7 @@ export const courierMock = {
 export const selectedOrderMock = {
   items: [
     {
-      options: { size: { _id: 'id', name: 'name' } },
+      options: { size: { _id: 'id', name: 'name' }, sidePocket: false },
       fixedPrice: 50,
       product: { _id: '_id', name: 'name', basePrice: 50 },
       quantity: 100
@@ -50,20 +65,87 @@ export const selectedOrderMock = {
 export const deliveryMock = {
   sentBy: deliveryTypes.novaPost,
   courier: courierMock,
-  novaPost: novaPostMock,
+  novaPost: novaPostWithDataMock,
   ukrPost: ukrPostMock,
   worldWide: worldWideMock
 };
 
-export const setFormMock = {
-  delivery: deliveryMock,
+export const deliveryByNovaPostMock = {
+  sentBy: deliveryTypes.novaPost,
+  ...courierMock,
+  ...ukrPostMock,
+  ...worldWideMock,
+  ...novaPostWithDataMock
+};
+
+export const deliveryByWorldWideMock = {
+  sentBy: deliveryTypes.worldWide,
+  ...courierMock,
+  ...novaPostMock,
+  ...ukrPostMock,
+  ...worldWideWithDataMock
+};
+
+export const setFormMock = (post) => ({
   status: 'test',
   paymentMethod: 'CARD',
-  isPaid: 'isPaid',
+  isPaid: 'PAID',
   recipient: 'recipient',
   user_id: 'user_id',
   userComment: 'comment',
+  promoCodeId: '',
+  delivery: typeDelivery(post),
   items: selectedOrderMock.items
+});
+
+const typeDelivery = (post) => {
+  if (post === 'novaPost') {
+    return deliveryByNovaPostMock;
+  } if (post === 'worldWide') {
+    return deliveryByWorldWideMock;
+  } 
+    return deliveryMock;
+  
+};
+
+export const newOrderMock = {
+  status: 'test',
+  paymentMethod: 'CARD',
+  isPaid: 'PAID',
+  recipient: 'recipient',
+  paymentStatus: 'PAID',
+  promoCodeId: '',
+  user_id: 'user_id',
+  userComment: 'comment',
+  items: [
+    {
+      isFromConstructor: false,
+      options: { size: 'id', sidePocket: false },
+      product: '_id',
+      quantity: 100
+    }
+  ],
+  delivery: {
+    byCourier: false,
+    city: 'Lviv',
+    cityCode: '',
+    cityId: '',
+    courierOffice: 'office 42',
+    district: '',
+    districtId: '',
+    flat: '',
+    house: '',
+    messenger: '',
+    messengerPhone: '',
+    region: '',
+    regionId: '',
+    sentBy: 'NOVAPOST',
+    stateOrProvince: '',
+    street: '',
+    worldWideCity: '',
+    worldWideCountry: '',
+    worldWideStreet: ''
+  }
 };
 
 export const selectedProductMock = {


### PR DESCRIPTION
## Description

When we change a checkbox on paid, the payment status does not change. But now it works when we create and change an order. 
Also admin cannot change the payment status when the user pays by card. The checkbox is disabled.

#### Screenshots

1) Go to Orders page.
![Order create](https://user-images.githubusercontent.com/83120263/199187145-f7a7b5f9-f24f-40e5-8b1a-de3c6fafce77.jpg)

2) Click on edit order icon.
3) Change payment checkbox to true.
![Order is paid](https://user-images.githubusercontent.com/83120263/199187233-f8df5a5f-1785-48dc-8dd8-02103f97dfe9.jpg)

4) Return back to orders page, and payment status is changed.
![Satus is refreshes](https://user-images.githubusercontent.com/83120263/199187323-260a9bce-efc8-4c8b-9cb9-11d245602085.jpg)

Admin cannot change the payment status
![Card](https://user-images.githubusercontent.com/83120263/199187489-e3541dca-930d-4708-b237-ea515017e15b.jpg)

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅ All tests passed locally and linter has no warnings and errors
- [x] ✨ My changes working with up-to-date front-end and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
