### PR TITLE
button is disabled when payment method is card

### DIFF
--- a/src/pages/order-item/tabs/general.js
+++ b/src/pages/order-item/tabs/general.js
@@ -87,6 +87,7 @@ const General = ({ data, handleChange, inputOptions }) => {
           checked={isPaid}
           name={inputName.isPaidInput}
           onChange={handleChange}
+          disabled={paymentMethod === 'CARD'}
         />
       </div>
     </div>


### PR DESCRIPTION
## Description

Admin cannot change the payment status when the user pays by card.

#### Screenshots

![Card](https://user-images.githubusercontent.com/83120263/200006818-a03c5008-e27a-491c-a634-7d650913cbe8.jpg)

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅ All tests passed locally and linter has no warnings and errors
- [x] ✨ My changes working with up-to-date front-end and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
