### PR TITLE
Disabled 'Відповідна ціна в UAH' displaying when pattern price is relative

### DIFF
--- a/src/components/forms/pattern-form/pattern-form.js
+++ b/src/components/forms/pattern-form/pattern-form.js
@@ -434,7 +434,7 @@ const PatternForm = ({ pattern, id, isEdit }) => {
                   {errors.additionalPrice}
                 </div>
               )}
-              {values.additionalPriceType === 'ABSOLUTE' ? (
+              {values.additionalPriceType === 'ABSOLUTE' ?? (
                 <TextField
                   id='outlined-basic'
                   variant='outlined'
@@ -446,8 +446,6 @@ const PatternForm = ({ pattern, id, isEdit }) => {
                   value={calculateAddittionalPriceValue(values, exchangeRate)}
                   disabled
                 />
-              ) : (
-                <></>
               )}
             </Paper>
           </Grid>

--- a/src/components/forms/pattern-form/pattern-form.js
+++ b/src/components/forms/pattern-form/pattern-form.js
@@ -434,17 +434,21 @@ const PatternForm = ({ pattern, id, isEdit }) => {
                   {errors.additionalPrice}
                 </div>
               )}
-              <TextField
-                id='outlined-basic'
-                variant='outlined'
-                label={convertationTitle}
-                className={`
-                  ${styles.textField} 
-                  ${styles.currencyField}
+              {values.additionalPriceType === 'ABSOLUTE' ? (
+                <TextField
+                  id='outlined-basic'
+                  variant='outlined'
+                  label={convertationTitle}
+                  className={`
+                    ${styles.textField} 
+                    ${styles.currencyField}
                   `}
-                value={calculateAddittionalPriceValue(values, exchangeRate)}
-                disabled
-              />
+                  value={calculateAddittionalPriceValue(values, exchangeRate)}
+                  disabled
+                />
+              ) : (
+                <></>
+              )}
             </Paper>
           </Grid>
           {map(languages, (lang) => (

--- a/src/components/forms/pattern-form/pattern-form.js
+++ b/src/components/forms/pattern-form/pattern-form.js
@@ -434,7 +434,7 @@ const PatternForm = ({ pattern, id, isEdit }) => {
                   {errors.additionalPrice}
                 </div>
               )}
-              {values.additionalPriceType === 'ABSOLUTE' ?? (
+              {values.additionalPriceType === 'ABSOLUTE' && (
                 <TextField
                   id='outlined-basic'
                   variant='outlined'

--- a/src/components/forms/pattern-form/tests/pattern-form.spec.js
+++ b/src/components/forms/pattern-form/tests/pattern-form.spec.js
@@ -68,8 +68,8 @@ describe('Basics form tests', () => {
     expect(mockUseDispatchFn).toHaveBeenCalledTimes(3);
   });
 
-  it('Should render 9 inputs', () => {
-    expect(component.find('input')).toHaveLength(9);
+  it('Should render 10 inputs', () => {
+    expect(component.find('input')).toHaveLength(10);
   });
 
   it('should call setFieldValue for checkbox', () => {

--- a/src/components/forms/pattern-form/tests/pattern-form.spec.js
+++ b/src/components/forms/pattern-form/tests/pattern-form.spec.js
@@ -68,8 +68,8 @@ describe('Basics form tests', () => {
     expect(mockUseDispatchFn).toHaveBeenCalledTimes(3);
   });
 
-  it('Should render 10 inputs', () => {
-    expect(component.find('input')).toHaveLength(10);
+  it('Should render 9 inputs', () => {
+    expect(component.find('input')).toHaveLength(9);
   });
 
   it('should call setFieldValue for checkbox', () => {


### PR DESCRIPTION
## Description

Disabled 'Відповідна ціна в UAH' displaying when price is relative

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅ All tests passed locally and linter has no warnings and errors
- [x] ✨ My changes working with up-to-date front-end and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
