### PR TITLE
Email-question page changed after answering to the question

### DIFF
--- a/src/redux/email-questions/email-questions.sagas.js
+++ b/src/redux/email-questions/email-questions.sagas.js
@@ -127,7 +127,7 @@ export function* handleAnswerEmailQuestion({ payload }) {
         )
       );
 
-      yield call(handleReloadingPendingQuestionsCount, emailQuestions);
+      yield call(handlePendingEmailQuestionsCount);
 
       yield put(setEmailQuestionLoading(false));
       yield put(push(routes.pathToEmailQuestions));
@@ -159,11 +159,6 @@ export function* handleEmailQuestionsDelete({ payload }) {
   } catch (error) {
     yield call(handleEmailQuestionError, error);
   }
-}
-
-export function* handleReloadingPendingQuestionsCount(list) {
-  const count = list.filter((item) => item.status === 'PENDING').length;
-  yield put(setEmailQuestionsPendingCount(count - 1));
 }
 
 export function* handleGettingQuestionFromStore() {


### PR DESCRIPTION
## Description

After answering to the question on sidebar quantity of questions is wrong.
Only after loading correct number is displayed. 

Now it works corectly. Amount of questions changing after answering.

#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| ![image](https://user-images.githubusercontent.com/83120263/204592878-b9b30345-fc25-4f02-93ad-a4ffd896c041.png) | ![image](https://user-images.githubusercontent.com/83120263/204592965-b24ebbb9-92c6-422a-908b-6512bbb4539b.png) |

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅ All tests passed locally and linter has no warnings and errors
- [x] ✨ My changes working with up-to-date front-end and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
