### PR TITLE
Sidebar works when error appears

### DIFF
--- a/src/components/error-boundary/error-boundary.js
+++ b/src/components/error-boundary/error-boundary.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { setError } from '../../redux/error/error.actions';
+import { withRouter } from 'react-router';
 
 import ErrorPage from '../../pages/error-page';
 
@@ -16,6 +17,16 @@ class ErrorBoundary extends React.Component {
 
   static getDerivedStateFromError() {
     return { hasError: true };
+  }
+
+  componentDidUpdate(previousProps, previousState) {
+    if (
+      previousState.hasError &&
+      this.props.location !== '/error' &&
+      previousProps.location !== this.props.location
+    ) {
+      this.setState({ hasError: false });
+    }
   }
 
   componentDidCatch() {
@@ -34,4 +45,4 @@ const mapDispatchToProps = {
   setError
 };
 
-export default connect(null, mapDispatchToProps)(ErrorBoundary);
+export default withRouter(connect(null, mapDispatchToProps)(ErrorBoundary));

--- a/src/pages/error-page/error-page.js
+++ b/src/pages/error-page/error-page.js
@@ -16,7 +16,7 @@ const ErrorPage = () => {
   }));
   useEffect(() => {
     if (!errorMessage) {
-      dispatch(push('/'));
+      dispatch(push('/error'));
     }
   }, [dispatch, errorMessage]);
 
@@ -29,7 +29,7 @@ const ErrorPage = () => {
           ? ERROR_BOUNDARY_STATUS
           : ERROR_PAGE_STATUS}
       </h2>
-      <Link to='/' onClick={() => window.location.reload()}>
+      <Link to='/'>
         <Button variant='contained'>На головну</Button>
       </Link>
     </div>


### PR DESCRIPTION
## Description

Create posibility to use sidebar  when error appears.
Add route to errors

#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| ** original screenshot ** | ** updated screenshot ** |

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅ All tests passed locally and linter has no warnings and errors
- [x] ✨ My changes working with up-to-date front-end and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
