### PR TITLE
Remove erorr hint for 'goods' select field on focus out

### DIFF
--- a/src/pages/order-item/tabs/add-product-form/add-product-form.js
+++ b/src/pages/order-item/tabs/add-product-form/add-product-form.js
@@ -126,7 +126,6 @@ const AddProductForm = ({
   };
 
   const sizeItems = setSizeItems(sizes);
-  const isFieldError = (field) => Boolean(touched[field] && errors[field]);
   const certificateOrPromoCode =
     promoCode?.getPromoCodeById || certificate?.getCertificateById;
 
@@ -145,8 +144,8 @@ const AddProductForm = ({
       }`}</ListItem>
       <ListItem disableGutters>{`${discount.discount} ${
         certificateOrPromoCode.categories
-          ? `${certificateOrPromoCode.discount }%`
-          : `${certificateOrPromoCode.value }грн.`
+          ? `${certificateOrPromoCode.discount}%`
+          : `${certificateOrPromoCode.value}грн.`
       }`}</ListItem>
       {certificateOrPromoCode.categories && (
         <ListItem disableGutters>{`${
@@ -202,7 +201,6 @@ const AddProductForm = ({
             <TextField
               {...params}
               label={productLabels.product}
-              error={isFieldError(inputName.items)}
               variant={materialUiConstants.outlined}
               InputProps={{
                 ...params.InputProps,
@@ -216,9 +214,6 @@ const AddProductForm = ({
             />
           )}
         />
-        {isFieldError(inputName.items) && (
-          <div className={styles.inputError}>{errors[inputName.items]}</div>
-        )}
         <div className={styles.quantity}>
           {productLabels.quantity}
           <Button

--- a/src/pages/order-item/tabs/add-product-form/add-product-form.styles.js
+++ b/src/pages/order-item/tabs/add-product-form/add-product-form.styles.js
@@ -1,9 +1,6 @@
 import { makeStyles } from '@material-ui/core/styles';
-import { formStyles } from '../../../../configs/styles';
 
-export const useStyles = makeStyles((theme) => {
-  const { inputError } = formStyles(theme);
-  return {
+export const useStyles = makeStyles((theme) => ({
     quantity: {
       display: 'flex',
       justifyContent: 'flex-start',
@@ -48,7 +45,5 @@ export const useStyles = makeStyles((theme) => {
       color: 'red',
       fontSize: '12px',
       height: '12px'
-    },
-    inputError
-  };
-});
+    }
+  }));


### PR DESCRIPTION
## Description

Removed erorr hint for 'goods' select field on focus out
Bug: https://github.com/ita-social-projects/horondi_admin/issues/1447

#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| **![Original](https://user-images.githubusercontent.com/47824060/204648902-39a95368-2cf8-4439-9855-7b617be739aa.jpg)** | **![Updated](https://user-images.githubusercontent.com/47824060/204647490-6b0813b2-da57-4036-8a5e-66d7c03b3fd6.jpg)** |



### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date admin and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
