### PR TITLE
Fixed error when focus out input with chosen product

### DIFF
--- a/src/pages/order-item/tabs/add-product-form/add-product-form.js
+++ b/src/pages/order-item/tabs/add-product-form/add-product-form.js
@@ -244,7 +244,8 @@ const AddProductForm = ({
               error={isFieldError(inputName.items)}
               variant={materialUiConstants.outlined}
               helperText={
-                isFieldError(inputName.items) && errors[inputName.items]
+                (isFieldError(inputName.items) && errors[inputName.items]) ||
+                ' '
               }
               InputProps={{
                 ...params.InputProps,

--- a/src/pages/order-item/tabs/add-product-form/add-product-form.js
+++ b/src/pages/order-item/tabs/add-product-form/add-product-form.js
@@ -165,7 +165,8 @@ const AddProductForm = ({
   };
 
   const sizeItems = setSizeItems(sizes);
-  const isFieldError = (field) => Boolean(touched[field]) && !productInput;
+  const isFieldError = (field) =>
+    Boolean(touched[field] && errors[field]) && !productInput;
   const certificateOrPromoCode =
     promoCode?.getPromoCodeById || certificate?.getCertificateById;
 
@@ -244,8 +245,7 @@ const AddProductForm = ({
               error={isFieldError(inputName.items)}
               variant={materialUiConstants.outlined}
               helperText={
-                (isFieldError(inputName.items) && errors[inputName.items]) ||
-                ' '
+                isFieldError(inputName.items) ? errors[inputName.items] : ' '
               }
               InputProps={{
                 ...params.InputProps,

--- a/src/pages/order-item/tabs/add-product-form/add-product-form.js
+++ b/src/pages/order-item/tabs/add-product-form/add-product-form.js
@@ -165,7 +165,7 @@ const AddProductForm = ({
   };
 
   const sizeItems = setSizeItems(sizes);
-  const isFieldError = (field) => Boolean(touched[field] && errors[field]);
+  const isFieldError = (field) => Boolean(touched[field]) && !productInput;
   const certificateOrPromoCode =
     promoCode?.getPromoCodeById || certificate?.getCertificateById;
 
@@ -243,6 +243,9 @@ const AddProductForm = ({
               label={productLabels.product}
               error={isFieldError(inputName.items)}
               variant={materialUiConstants.outlined}
+              helperText={
+                isFieldError(inputName.items) && errors[inputName.items]
+              }
               InputProps={{
                 ...params.InputProps,
                 endAdornment: (
@@ -255,9 +258,7 @@ const AddProductForm = ({
             />
           )}
         />
-        {isFieldError(inputName.items) && (
-          <div className={styles.inputError}>{errors[inputName.items]}</div>
-        )}
+
         <div className={styles.quantity}>
           {productLabels.quantity}
           <Button

--- a/src/pages/order-item/tabs/add-product-form/add-product-form.styles.js
+++ b/src/pages/order-item/tabs/add-product-form/add-product-form.styles.js
@@ -51,7 +51,6 @@ export const useStyles = makeStyles((theme) => {
       color: 'red',
       fontSize: '12px',
       height: '12px'
-    },
-    inputError
+    }
   };
 });


### PR DESCRIPTION
## Description

When we don't select a product and remove the focus from the input, the error "field cannot be empty" is displayed.
We don't have an error when we select product.

#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| ![Знімок екрана 2022-12-02 175245](https://user-images.githubusercontent.com/83120263/205334898-d6b8277b-525d-43f7-be6c-630fd7c5edd7.jpg) | ![Знімок екрана 2022-12-02 175501](https://user-images.githubusercontent.com/83120263/205334972-4958a443-a4db-4c4a-9b8a-7db791517b07.jpg)
 |![Знімок екрана 2022-12-02 175259](https://user-images.githubusercontent.com/83120263/205334993-9ff5f6a1-587c-47f6-9996-1630c4faaacf.jpg) | ![Знімок екрана 2022-12-02 175522](https://user-images.githubusercontent.com/83120263/205335017-d3edfdb2-7062-4990-9c94-6772c89fdfbf.jpg) |

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅ All tests passed locally and linter has no warnings and errors
- [x] ✨ My changes working with up-to-date front-end and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
