### PR TITLE
Removed 'learn more' link from slider

### DIFF
--- a/src/components/draganddrop/slide/slide.js
+++ b/src/components/draganddrop/slide/slide.js
@@ -9,8 +9,6 @@ import { useStyles } from './slide.styles';
 
 const Slide = ({ slide, index }) => {
   const styles = useStyles();
-  const { discoverMoreTitle, discoverMoreSymbol } =
-    config.titles.homePageSliderTitle;
   const { IMG_URL } = config;
   return (
     <Draggable
@@ -43,11 +41,6 @@ const Slide = ({ slide, index }) => {
                 <h3>{slide.title[0].value}</h3>
                 <p>{slide.description[0].value}</p>
               </div>
-              <p className={styles.discoverMore}>
-                {' '}
-                {discoverMoreTitle}
-                <span>{discoverMoreSymbol}</span>
-              </p>
             </div>
           </Paper>
         </Container>

--- a/src/configs/titles.js
+++ b/src/configs/titles.js
@@ -130,8 +130,6 @@ const titles = {
   homePageSliderTitle: {
     mainPageTitle: 'Слайди на головній сторінці',
     slideOrderTitle: 'Порядок слайдів',
-    discoverMoreTitle: 'Дізнатись більше',
-    discoverMoreSymbol: '→',
     slideTitle: 'Заголовок слайду не вибрано',
     slideDescription: 'Опис слайду не вибрано',
     preview: 'Попередній перегляд'


### PR DESCRIPTION
## Description

Removed 'learn more' link from slider on the Static pages -> Main page -> Slider.

#### Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
|![image](https://user-images.githubusercontent.com/79856961/207348514-02e01a6a-ad4c-4b76-b7d6-a6e33e840b27.png)|![image](https://user-images.githubusercontent.com/79856961/207348294-1744d366-af13-4b8f-9124-54428b91a0c8.png)|

### Checklist

- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅ All tests passed locally and linter has no warnings and errors
- [x] ✨ My changes working with up-to-date front-end and back-end part locally, like charm
- [x] 🔗 Link pull request to issue
